### PR TITLE
Fix daemon/project regressions and realign dev workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,13 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback
 
+# Doubao / Miaoji ASR
+# Docs: https://www.volcengine.com/docs/6561/1798094
+DOUBAO_ENDPOINT=
+DOUBAO_APP_KEY=
+DOUBAO_ACCESS_KEY=
+DOUBAO_RESOURCE_ID=
+
 # S3 / CloudFront
 S3_BUCKET=
 S3_REGION=us-west-2

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ apps/web/test-results/
 # local settings
 .claude/
 .tool-versions
+.pnpm-store/
+.worktrees/
+agent-skills/
 
 # feature tracking
 _features/

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ dev:
 	cd server && go run ./cmd/server
 
 daemon:
-	@$(MAKE) multica MULTICA_ARGS="daemon"
+	@$(MAKE) multica MULTICA_ARGS="daemon start $(ARGS)"
 
 cli:
 	@$(MAKE) multica MULTICA_ARGS="$(MULTICA_ARGS)"

--- a/README.md
+++ b/README.md
@@ -1,167 +1,112 @@
-<p align="center">
-  <img src="docs/assets/banner.jpg" alt="Multica — humans and agents, side by side" width="100%">
-</p>
+# MyTeam
 
-<div align="center">
+[![CI](https://github.com/MyAIOSHub/MyTeam/actions/workflows/ci.yml/badge.svg)](https://github.com/MyAIOSHub/MyTeam/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/MyAIOSHub/MyTeam?style=social)](https://github.com/MyAIOSHub/MyTeam)
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-light.svg">
-  <img alt="Multica" src="docs/assets/logo-light.svg" width="50">
-</picture>
+AI-native task management for humans and coding agents.
 
-# Multica
+[中文说明](README.zh-CN.md) · [Self-Hosting](SELF_HOSTING.md) · [CLI and Daemon](CLI_AND_DAEMON.md) · [Contributing](CONTRIBUTING.md)
 
-**Your next 10 hires won't be human.**
+MyTeam gives your team a shared workspace where humans and agents can pick up work, run sessions, manage projects, and collaborate through local or remote runtimes.
 
-Open-source platform that turns coding agents into real teammates.<br/>
-Assign tasks, track progress, compound skills — manage your human + agent workforce in one place.
+## What You Get
 
-[![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
+- Agent-first issues, projects, and execution sessions
+- Local daemon support for CLI-based coding agents
+- Web app and desktop control plane in the same repository
+- PostgreSQL + pgvector backend with realtime updates over WebSocket
+- Built-in support for files, comments, workspace members, and agent runtimes
 
-[Website](https://multica.ai) · [Cloud](https://multica.ai/app) · [Self-Hosting](SELF_HOSTING.md) · [Contributing](CONTRIBUTING.md)
+## Quick Start
 
-**English | [简体中文](README.zh-CN.md)**
+### Prerequisites
 
-</div>
+- Node.js 22
+- pnpm
+- Go 1.26.1
+- Docker / Docker Compose
 
-## What is Multica?
-
-Multica turns coding agents into real teammates. Assign issues to an agent like you'd assign to a colleague — they'll pick up the work, write code, report blockers, and update statuses autonomously.
-
-No more copy-pasting prompts. No more babysitting runs. Your agents show up on the board, participate in conversations, and compound reusable skills over time. Works with **Claude Code** and **Codex**.
-
-<p align="center">
-  <img src="docs/assets/hero-screenshot.png" alt="Multica board view" width="800">
-</p>
-
-## Features
-
-- **Agents as Teammates** — assign to an agent like you'd assign to a colleague. They have profiles, show up on the board, post comments, create issues, and report blockers proactively.
-- **Autonomous Execution** — set it and forget it. Full task lifecycle management (enqueue, claim, start, complete/fail) with real-time progress streaming via WebSocket.
-- **Reusable Skills** — every solution becomes a reusable skill for the whole team. Deployments, migrations, code reviews — skills compound your team's capabilities over time.
-- **Unified Runtimes** — one dashboard for all your compute. Local daemons and cloud runtimes, auto-detection of available CLIs, real-time monitoring.
-- **Multi-Workspace** — organize work across teams with workspace-level isolation. Each workspace has its own agents, issues, and settings.
-
-## Getting Started
-
-### Multica Cloud
-
-The fastest way to get started — no setup required: **[multica.ai](https://multica.ai)**
-
-### Self-Host with Docker
+### Run Locally
 
 ```bash
-git clone https://github.com/multica-ai/multica.git
-cd multica
-cp .env.example .env
-# Edit .env — at minimum, change JWT_SECRET
-
-docker compose up -d                              # Start PostgreSQL
-cd server && go run ./cmd/migrate up && cd ..     # Run migrations
-make start                                         # Start the app
-```
-
-See the [Self-Hosting Guide](SELF_HOSTING.md) for full instructions.
-
-## CLI
-
-The `multica` CLI connects your local machine to Multica — authenticate, manage workspaces, and run the agent daemon.
-
-```bash
-# Install
-brew tap multica-ai/tap
-brew install multica
-
-# Authenticate and start
-multica login
-multica daemon start
-```
-
-The daemon auto-detects available agent CLIs (`claude`, `codex`) on your PATH. When an agent is assigned a task, the daemon creates an isolated environment, runs the agent, and reports results back.
-
-See the [CLI and Daemon Guide](CLI_AND_DAEMON.md) for the full command reference, daemon configuration, and advanced usage.
-
-### Personal agent runner
-
-Each user automatically gets a personal agent (`<User>'s Assistant`) that replies via the Claude Agent SDK (Python). To enable replies:
-
-1. Install Python 3.10+ and the SDK:
-   ```bash
-   make setup-agent-runner
-   ```
-2. Set `AGENT_LLM_API_KEY`, `AGENT_LLM_BASE_URL`, and `AGENT_LLM_MODEL` in `.env` (see `.env.example`). Bailian (OpenAI-compatible) is the default; Anthropic API is supported by setting `AGENT_KERNEL=anthropic`.
-3. Restart the backend.
-
-If the API key is missing, the agent is created but replies fail with a `system_notification` message in the conversation rather than silently dropping.
-
-## Quickstart
-
-Once you have the CLI installed (or signed up for [Multica Cloud](https://multica.ai)), follow these steps to assign your first task to an agent:
-
-### 1. Log in and start the daemon
-
-```bash
-multica login           # Authenticate with your Multica account
-multica daemon start    # Start the local agent runtime
-```
-
-The daemon runs in the background and keeps your machine connected to Multica. It auto-detects agent CLIs (`claude`, `codex`) available on your PATH.
-
-### 2. Verify your runtime
-
-Open your workspace in the Multica web app. Navigate to **Settings → Runtimes** — you should see your machine listed as an active **Runtime**.
-
-> **What is a Runtime?** A Runtime is a compute environment that can execute agent tasks. It can be your local machine (via the daemon) or a cloud instance. Each runtime reports which agent CLIs are available, so Multica knows where to route work.
-
-### 3. Create an agent
-
-Go to **Settings → Agents** and click **New Agent**. Pick the runtime you just connected and choose a provider (Claude Code or Codex). Give your agent a name — this is how it will appear on the board, in comments, and in assignments.
-
-### 4. Assign your first task
-
-Create an issue from the board (or via `multica issue create`), then assign it to your new agent. The agent will automatically pick up the task, execute it on your runtime, and report progress — just like a human teammate.
-
-That's it! Your agent is now part of the team. 🎉
-
-## Architecture
-
-```
-┌──────────────┐     ┌──────────────┐     ┌──────────────────┐
-│   Next.js    │────>│  Go Backend  │────>│   PostgreSQL     │
-│   Frontend   │<────│  (Chi + WS)  │<────│   (pgvector)     │
-└──────────────┘     └──────┬───────┘     └──────────────────┘
-                            │
-                     ┌──────┴───────┐
-                     │ Agent Daemon │  (runs on your machine)
-                     │ Claude/Codex │
-                     └──────────────┘
-```
-
-| Layer | Stack |
-|-------|-------|
-| Frontend | Next.js 16 (App Router) |
-| Backend | Go (Chi router, sqlc, gorilla/websocket) |
-| Database | PostgreSQL 17 with pgvector |
-| Agent Runtime | Local daemon executing Claude Code or Codex |
-
-## Development
-
-For contributors working on the Multica codebase, see the [Contributing Guide](CONTRIBUTING.md).
-
-**Prerequisites:** [Node.js](https://nodejs.org/) v20+, [pnpm](https://pnpm.io/) v10.28+, [Go](https://go.dev/) v1.26+, [Docker](https://www.docker.com/)
-
-```bash
-pnpm install
+git clone https://github.com/MyAIOSHub/MyTeam.git
+cd MyTeam
 cp .env.example .env
 make setup
 make start
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow, worktree support, testing, and troubleshooting.
+Once the app is up:
 
-## License
+- Web app: `http://localhost:3000`
+- API server: `http://localhost:8080`
 
-[Apache 2.0](LICENSE)
+### Run the Local Daemon
+
+```bash
+make daemon
+```
+
+Useful shortcuts:
+
+```bash
+make daemon-status
+make daemon-logs
+make myteam ARGS="daemon stop"
+```
+
+If you prefer to invoke the CLI directly:
+
+```bash
+cd server
+go run ./cmd/myteam daemon start
+```
+
+The daemon auto-detects locally available coding CLIs such as `codex` and `claude` when they are installed.
+
+### Run the Desktop App
+
+```bash
+pnpm --filter @myteam/desktop dev
+```
+
+The desktop app expects the backend to be running locally.
+
+## Project Layout
+
+| Path | Purpose |
+| --- | --- |
+| `apps/web/` | Next.js web client |
+| `apps/desktop/` | Electron desktop app |
+| `server/` | Go API server, CLI, daemon, sqlc queries, and migrations |
+| `e2e/` | Playwright end-to-end tests |
+| `scripts/` | Local setup, verification, and environment helpers |
+
+## Common Commands
+
+| Command | Description |
+| --- | --- |
+| `make setup` | Install dependencies, start PostgreSQL, and run migrations |
+| `make start` | Start the backend and web app together |
+| `make daemon` | Start the local daemon |
+| `make build` | Build the Go server and CLI binaries |
+| `make test` | Run backend Go tests |
+| `pnpm typecheck` | Run web TypeScript type checks |
+| `pnpm test` | Run web unit tests |
+| `pnpm --filter @myteam/desktop typecheck` | Run desktop type checks |
+| `pnpm --filter @myteam/desktop test` | Run desktop unit tests |
+| `make check` | Run the full verification pipeline |
+| `make worktree-env` | Generate a worktree-specific `.env.worktree` |
+
+## Development Notes
+
+- CI runs frontend build/typecheck/tests, desktop typecheck/tests, and backend Go tests against PostgreSQL with pgvector.
+- For isolated local development, use `make setup-worktree` and `make start-worktree`.
+- Some environment variables and legacy internal entry points still use the `MULTICA_` prefix or the `multica` binary name. Day-to-day use can go through the `myteam` entry points documented above.
+
+## Additional Docs
+
+- [SELF_HOSTING.md](SELF_HOSTING.md)
+- [CLI_AND_DAEMON.md](CLI_AND_DAEMON.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,154 +1,112 @@
-<p align="center">
-  <img src="docs/assets/banner.jpg" alt="Multica — 人类与 AI，并肩前行" width="100%">
-</p>
+# MyTeam
 
-<div align="center">
+[![CI](https://github.com/MyAIOSHub/MyTeam/actions/workflows/ci.yml/badge.svg)](https://github.com/MyAIOSHub/MyTeam/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/MyAIOSHub/MyTeam?style=social)](https://github.com/MyAIOSHub/MyTeam)
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-light.svg">
-  <img alt="Multica" src="docs/assets/logo-light.svg" width="50">
-</picture>
+面向人类协作者和编码 Agent 的 AI 原生任务管理平台。
 
-# Multica
+[English README](README.md) · [自托管说明](SELF_HOSTING.md) · [CLI 与 Daemon](CLI_AND_DAEMON.md) · [贡献指南](CONTRIBUTING.md)
 
-**你的下一批员工，不是人类。**
+MyTeam 提供一个共享工作空间，让团队成员和 Agent 可以一起处理 issue、项目、执行会话与文件协作，并同时支持本地和远程 runtime。
 
-开源平台，将编码 Agent 变成真正的队友。<br/>
-分配任务、跟踪进度、积累技能——在一个地方管理你的人类 + Agent 团队。
+## 项目能力
 
-[![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
-
-[官网](https://multica.ai) · [云服务](https://multica.ai/app) · [自部署指南](SELF_HOSTING.md) · [参与贡献](CONTRIBUTING.md)
-
-**[English](README.md) | 简体中文**
-
-</div>
-
-## Multica 是什么？
-
-Multica 将编码 Agent 变成真正的队友。像分配给同事一样分配给 Agent——它们会自主接手工作、编写代码、报告阻塞问题、更新状态。
-
-不再需要复制粘贴 prompt，不再需要盯着运行过程。你的 Agent 出现在看板上、参与对话、随着时间积累可复用的技能。支持 **Claude Code** 和 **Codex**。
-
-<p align="center">
-  <img src="docs/assets/hero-screenshot.png" alt="Multica 看板视图" width="800">
-</p>
-
-## 功能特性
-
-- **Agent 即队友** — 像分配给同事一样分配给 Agent。它们有个人档案、出现在看板上、发表评论、创建 Issue、主动报告阻塞问题。
-- **自主执行** — 设置后无需管理。完整的任务生命周期管理（排队、认领、执行、完成/失败），通过 WebSocket 实时推送进度。
-- **可复用技能** — 每个解决方案都成为全团队可复用的技能。部署、数据库迁移、代码审查——技能让团队能力随时间持续增长。
-- **统一运行时** — 一个控制台管理所有算力。本地 daemon 和云端运行时，自动检测可用 CLI，实时监控。
-- **多工作区** — 按团队组织工作，工作区级别隔离。每个工作区有独立的 Agent、Issue 和设置。
+- 以 Agent 为一等公民的 issue、project 与执行会话
+- 支持本地 daemon，方便接入 CLI 型编码 Agent
+- 同仓库提供 Web 应用与桌面控制台
+- 基于 PostgreSQL + pgvector，使用 WebSocket 做实时更新
+- 内置文件、评论、工作区成员和 agent runtime 管理
 
 ## 快速开始
 
-### Multica 云服务
+### 环境要求
 
-最快的上手方式，无需任何配置：**[multica.ai](https://multica.ai)**
+- Node.js 22
+- pnpm
+- Go 1.26.1
+- Docker / Docker Compose
 
-### Docker 自部署
-
-```bash
-git clone https://github.com/multica-ai/multica.git
-cd multica
-cp .env.example .env
-# 编辑 .env — 至少修改 JWT_SECRET
-
-docker compose up -d                              # 启动 PostgreSQL
-cd server && go run ./cmd/migrate up && cd ..     # 运行数据库迁移
-make start                                         # 启动应用
-```
-
-完整部署文档请参阅 [自部署指南](SELF_HOSTING.md)。
-
-## CLI
-
-`multica` CLI 将你的本地机器连接到 Multica — 用于认证、管理工作区和运行 Agent daemon。
+### 本地启动
 
 ```bash
-# 安装
-brew tap multica-ai/tap
-brew install multica
-
-# 认证并启动
-multica login
-multica daemon start
-```
-
-daemon 会自动检测 PATH 中可用的 Agent CLI（`claude`、`codex`）。当 Agent 被分配任务时，daemon 会创建隔离环境、运行 Agent、并将结果回传。
-
-完整命令参考请参阅 [CLI 与 Daemon 指南](CLI_AND_DAEMON.md)。
-
-## 快速上手
-
-安装好 CLI（或注册 [Multica 云服务](https://multica.ai)）后，按以下步骤将第一个任务分配给 Agent：
-
-### 1. 登录并启动 daemon
-
-```bash
-multica login           # 使用你的 Multica 账号认证
-multica daemon start    # 启动本地 Agent 运行时
-```
-
-daemon 在后台运行，保持你的机器与 Multica 的连接。它会自动检测 PATH 中可用的 Agent CLI（`claude`、`codex`）。
-
-### 2. 确认运行时已连接
-
-在 Multica Web 端打开你的工作区，进入 **设置 → 运行时（Runtimes）**，你应该能看到你的机器已作为一个活跃的 **Runtime** 出现在列表中。
-
-> **什么是 Runtime（运行时）？** Runtime 是可以执行 Agent 任务的计算环境。它可以是你的本地机器（通过 daemon 连接），也可以是云端实例。每个 Runtime 会上报可用的 Agent CLI，Multica 据此决定将任务路由到哪里执行。
-
-### 3. 创建 Agent
-
-进入 **设置 → Agents**，点击 **新建 Agent**。选择你刚连接的 Runtime，选择 Provider（Claude Code 或 Codex），并为 Agent 起个名字——它将以这个名字出现在看板、评论和任务分配中。
-
-### 4. 分配你的第一个任务
-
-在看板上创建一个 Issue（或通过 `multica issue create` 命令创建），然后将其分配给你的新 Agent。Agent 会自动接手任务、在你的 Runtime 上执行、并实时汇报进度——就像一个真正的队友一样。
-
-大功告成！你的 Agent 现在是团队的一员了。 🎉
-
-## 架构
-
-```
-┌──────────────┐     ┌──────────────┐     ┌──────────────────┐
-│   Next.js    │────>│  Go 后端     │────>│   PostgreSQL     │
-│   前端       │<────│  (Chi + WS)  │<────│   (pgvector)     │
-└──────────────┘     └──────┬───────┘     └──────────────────┘
-                            │
-                     ┌──────┴───────┐
-                     │ Agent Daemon │  （运行在你的机器上）
-                     │ Claude/Codex │
-                     └──────────────┘
-```
-
-| 层级 | 技术栈 |
-|------|--------|
-| 前端 | Next.js 16 (App Router) |
-| 后端 | Go (Chi router, sqlc, gorilla/websocket) |
-| 数据库 | PostgreSQL 17 with pgvector |
-| Agent 运行时 | 本地 daemon 执行 Claude Code 或 Codex |
-
-## 开发
-
-参与 Multica 代码贡献，请参阅 [贡献指南](CONTRIBUTING.md)。
-
-**环境要求：** [Node.js](https://nodejs.org/) v20+, [pnpm](https://pnpm.io/) v10.28+, [Go](https://go.dev/) v1.26+, [Docker](https://www.docker.com/)
-
-```bash
-pnpm install
+git clone https://github.com/MyAIOSHub/MyTeam.git
+cd MyTeam
 cp .env.example .env
 make setup
 make start
 ```
 
-完整的开发流程、worktree 支持、测试和问题排查请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。
+启动后可访问：
 
-## 开源协议
+- Web 应用：`http://localhost:3000`
+- API 服务：`http://localhost:8080`
 
-[Apache 2.0](LICENSE)
+### 启动本地 Daemon
+
+```bash
+make daemon
+```
+
+常用快捷命令：
+
+```bash
+make daemon-status
+make daemon-logs
+make myteam ARGS="daemon stop"
+```
+
+如果你更习惯直接调用 CLI：
+
+```bash
+cd server
+go run ./cmd/myteam daemon start
+```
+
+当本机安装了 `codex`、`claude` 等 CLI 后，daemon 会自动识别可用运行时。
+
+### 启动桌面端
+
+```bash
+pnpm --filter @myteam/desktop dev
+```
+
+桌面端默认依赖本地后端服务。
+
+## 项目结构
+
+| 路径 | 说明 |
+| --- | --- |
+| `apps/web/` | Next.js Web 客户端 |
+| `apps/desktop/` | Electron 桌面应用 |
+| `server/` | Go API、CLI、daemon、sqlc 查询与数据库迁移 |
+| `e2e/` | Playwright 端到端测试 |
+| `scripts/` | 本地初始化、校验与环境辅助脚本 |
+
+## 常用命令
+
+| 命令 | 说明 |
+| --- | --- |
+| `make setup` | 安装依赖、启动 PostgreSQL 并执行迁移 |
+| `make start` | 同时启动后端与 Web 前端 |
+| `make daemon` | 启动本地 daemon |
+| `make build` | 构建 Go 服务端与 CLI 二进制 |
+| `make test` | 运行后端 Go 测试 |
+| `pnpm typecheck` | 运行 Web TypeScript 类型检查 |
+| `pnpm test` | 运行 Web 单元测试 |
+| `pnpm --filter @myteam/desktop typecheck` | 运行桌面端类型检查 |
+| `pnpm --filter @myteam/desktop test` | 运行桌面端单元测试 |
+| `make check` | 执行完整验证流水线 |
+| `make worktree-env` | 生成 worktree 专用的 `.env.worktree` |
+
+## 开发说明
+
+- CI 会执行前端构建、类型检查、单元测试，桌面端类型检查与单元测试，以及基于 PostgreSQL + pgvector 的后端 Go 测试。
+- 需要隔离开发环境时，可使用 `make setup-worktree` 与 `make start-worktree`。
+- 仓库内部仍有一部分历史遗留的 `MULTICA_` 环境变量前缀和 `multica` 二进制命名；日常使用可以优先走上面列出的 `myteam` 入口。
+
+## 更多文档
+
+- [SELF_HOSTING.md](SELF_HOSTING.md)
+- [CLI_AND_DAEMON.md](CLI_AND_DAEMON.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -27,7 +27,11 @@ const store = new Store<Record<string, string>>({
 });
 
 const nativeBridge = new NativeBridge(projectRoot);
-const runtimeController = new DesktopRuntimeController(projectRoot, apiBaseUrl);
+const runtimeController = new DesktopRuntimeController(
+  projectRoot,
+  apiBaseUrl,
+  Boolean(VITE_DEV_SERVER_URL),
+);
 
 let mainWindow: BrowserWindow | null = null;
 

--- a/apps/desktop/electron/runtime-controller.test.ts
+++ b/apps/desktop/electron/runtime-controller.test.ts
@@ -1,0 +1,23 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveRuntimeInvocation } from "./runtime-controller";
+
+describe("resolveRuntimeInvocation", () => {
+  const projectRoot = "/tmp/myteam";
+
+  it("uses go run from the server directory in development", () => {
+    expect(resolveRuntimeInvocation(projectRoot, true)).toEqual({
+      command: "go",
+      argsPrefix: ["run", "./cmd/myteam"],
+      cwd: path.join(projectRoot, "server"),
+    });
+  });
+
+  it("uses the built CLI binary outside development", () => {
+    expect(resolveRuntimeInvocation(projectRoot, false)).toEqual({
+      command: path.join(projectRoot, "server/bin/myteam"),
+      argsPrefix: [],
+      cwd: projectRoot,
+    });
+  });
+});

--- a/apps/desktop/electron/runtime-controller.ts
+++ b/apps/desktop/electron/runtime-controller.ts
@@ -10,10 +10,27 @@ const execFileAsync = promisify(execFile);
 // processes accumulating across renderer reconnects. Issue #45.
 const CLI_TIMEOUT_MS = 10_000;
 
+export function resolveRuntimeInvocation(projectRoot: string, devMode: boolean) {
+  if (devMode) {
+    return {
+      command: "go",
+      argsPrefix: ["run", "./cmd/myteam"],
+      cwd: path.join(projectRoot, "server"),
+    };
+  }
+
+  return {
+    command: path.join(projectRoot, "server/bin/myteam"),
+    argsPrefix: [] as string[],
+    cwd: projectRoot,
+  };
+}
+
 export class DesktopRuntimeController {
   constructor(
     private readonly projectRoot: string,
     private readonly serverUrl: string,
+    private readonly devMode = false,
   ) {}
 
   getCliPath() {
@@ -30,36 +47,47 @@ export class DesktopRuntimeController {
   // execOpts centralizes timeout + cwd + env so every call honors the
   // same kill deadline.
   private execOpts() {
+    const invocation = resolveRuntimeInvocation(this.projectRoot, this.devMode);
     return {
-      cwd: this.projectRoot,
+      cwd: invocation.cwd,
       env: this.baseEnv(),
       timeout: CLI_TIMEOUT_MS,
       killSignal: "SIGKILL" as const,
     };
   }
 
+  private invocation() {
+    return resolveRuntimeInvocation(this.projectRoot, this.devMode);
+  }
+
+  private async runCli(args: string[]) {
+    const invocation = this.invocation();
+    await execFileAsync(
+      invocation.command,
+      [...invocation.argsPrefix, ...args],
+      this.execOpts(),
+    );
+  }
+
   async startDaemon(): Promise<void> {
-    await execFileAsync(this.getCliPath(), ["daemon", "start"], this.execOpts());
+    await this.runCli(["daemon", "start"]);
   }
 
   async stopDaemon(): Promise<void> {
-    await execFileAsync(this.getCliPath(), ["daemon", "stop"], this.execOpts());
+    await this.runCli(["daemon", "stop"]);
   }
 
   async listRuntimes(): Promise<SessionRuntime[]> {
+    const invocation = this.invocation();
     const { stdout } = await execFileAsync(
-      this.getCliPath(),
-      ["runtime", "list", "--output", "json"],
+      invocation.command,
+      [...invocation.argsPrefix, "runtime", "list", "--output", "json"],
       this.execOpts(),
     );
     return JSON.parse(stdout) as SessionRuntime[];
   }
 
   async watchWorkspace(workspaceId: string): Promise<void> {
-    await execFileAsync(
-      this.getCliPath(),
-      ["workspace", "watch", workspaceId],
-      this.execOpts(),
-    );
+    await this.runCli(["workspace", "watch", workspaceId]);
   }
 }

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -182,13 +182,13 @@ function LoginPageContent() {
   // CLI confirm step: user is already logged in, just authorize.
   if (step === "cli_confirm" && existingUser) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[#08090a]">
-        <Card className="w-full max-w-sm bg-[#0f1011] border-[rgba(255,255,255,0.08)] rounded-xl">
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Card className="w-full max-w-sm rounded-xl">
           <CardHeader className="text-center">
-            <CardTitle className="text-2xl text-[#f7f8f8]">授权 CLI</CardTitle>
-            <CardDescription className="text-[#8a8f98]">
+            <CardTitle className="text-2xl">授权 CLI</CardTitle>
+            <CardDescription>
               允许 CLI 以{" "}
-              <span className="font-medium text-[#f7f8f8]">
+              <span className="font-medium text-foreground">
                 {existingUser.email}
               </span>{" "}
               的身份访问 My Team？
@@ -198,14 +198,14 @@ function LoginPageContent() {
             <Button
               onClick={handleCliAuthorize}
               disabled={submitting}
-              className="w-full bg-[#5e6ad2] hover:bg-[#828fff] text-white border-0"
+              className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
               size="lg"
             >
               {submitting ? "授权中..." : "授权"}
             </Button>
             <Button
               variant="ghost"
-              className="w-full text-[#8a8f98] hover:text-[#d0d6e0] hover:bg-[rgba(255,255,255,0.05)]"
+              className="w-full"
               onClick={() => {
                 setExistingUser(null);
                 setStep("email");
@@ -221,13 +221,13 @@ function LoginPageContent() {
 
   if (step === "code") {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[#08090a]">
-        <Card className="w-full max-w-sm bg-[#0f1011] border-[rgba(255,255,255,0.08)] rounded-xl">
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Card className="w-full max-w-sm rounded-xl">
           <CardHeader className="text-center">
-            <CardTitle className="text-2xl text-[#f7f8f8]">查看你的邮箱</CardTitle>
-            <CardDescription className="text-[#8a8f98]">
+            <CardTitle className="text-2xl">查看你的邮箱</CardTitle>
+            <CardDescription>
               我们已将验证码发送至{" "}
-              <span className="font-medium text-[#f7f8f8]">{email}</span>
+              <span className="font-medium text-foreground">{email}</span>
             </CardDescription>
           </CardHeader>
           <CardContent className="flex flex-col items-center gap-4">
@@ -252,12 +252,12 @@ function LoginPageContent() {
             {error && (
               <p className="text-sm text-destructive">{error}</p>
             )}
-            <div className="flex items-center gap-2 text-sm text-[#8a8f98]">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <button
                 type="button"
                 onClick={handleResend}
                 disabled={cooldown > 0}
-                className="text-[#7170ff] underline-offset-4 hover:underline disabled:text-[#8a8f98] disabled:no-underline disabled:cursor-not-allowed"
+                className="text-primary underline-offset-4 hover:underline disabled:text-muted-foreground disabled:no-underline disabled:cursor-not-allowed"
               >
                 {cooldown > 0 ? `${cooldown}秒后重新发送` : "重新发送验证码"}
               </button>
@@ -266,7 +266,7 @@ function LoginPageContent() {
           <CardFooter>
             <Button
               variant="ghost"
-              className="w-full text-[#7170ff] hover:text-[#828fff] hover:bg-[rgba(255,255,255,0.05)]"
+              className="w-full text-primary"
               onClick={() => {
                 setStep("email");
                 setCode("");
@@ -282,16 +282,16 @@ function LoginPageContent() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#08090a]">
-      <Card className="w-full max-w-sm bg-[#0f1011] border-[rgba(255,255,255,0.08)] rounded-xl">
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <Card className="w-full max-w-sm rounded-xl">
         <CardHeader className="text-center">
-          <CardTitle className="text-2xl font-bold text-[#f7f8f8]">My Team</CardTitle>
-          <CardDescription className="text-[#8a8f98]">让编程 Agent 成为真正的队友</CardDescription>
+          <CardTitle className="text-2xl font-bold">My Team</CardTitle>
+          <CardDescription>让编程 Agent 成为真正的队友</CardDescription>
         </CardHeader>
         <CardContent>
           <form id="login-form" onSubmit={handleSendCode} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="email" className="text-[#d0d6e0]">邮箱</Label>
+              <Label htmlFor="email">邮箱</Label>
               <Input
                 id="email"
                 type="email"
@@ -299,7 +299,6 @@ function LoginPageContent() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="bg-[rgba(255,255,255,0.02)] border-[rgba(255,255,255,0.08)] text-[#f7f8f8] placeholder:text-[#8a8f98]"
               />
             </div>
             {error && (
@@ -312,7 +311,7 @@ function LoginPageContent() {
             type="submit"
             form="login-form"
             disabled={submitting}
-            className="w-full bg-[#5e6ad2] hover:bg-[#828fff] text-white border-0"
+            className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
             size="lg"
           >
             {submitting ? "发送验证码中..." : "继续"}

--- a/apps/web/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/page.tsx
@@ -109,6 +109,11 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailProps) {
   } = useProjectStore();
 
   const [loading, setLoading] = useState(true);
+  const [loadErrors, setLoadErrors] = useState<{
+    project?: string;
+    versions?: string;
+    runs?: string;
+  }>({});
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleValue, setTitleValue] = useState("");
   const [forkOpen, setForkOpen] = useState(false);
@@ -206,21 +211,71 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailProps) {
   useEffect(() => {
     if (!id) return;
     setLoading(true);
-    const load = async () => {
+    setLoadErrors({});
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const describe = (err: unknown, fallback: string) => {
+      if (err instanceof Error && err.message) return err.message;
+      return fallback;
+    };
+
+    const isAbort = (err: unknown) =>
+      signal.aborted || (err as Error)?.name === "AbortError";
+
+    // Bypass the store's built-in try/catch so we can classify each fetch
+    // independently and expose per-call error state to the UI. On success
+    // we still push the results into the store so the rest of the page
+    // reacts as it did before.
+    const loadProject = async () => {
       try {
-        await Promise.all([
-          fetchProject(id),
-          fetchVersions(id),
-          fetchRuns(id),
-        ]);
-      } catch {
-        toast.error("加载项目失败");
-      } finally {
-        setLoading(false);
+        const project = await api.getProject(id, { signal });
+        if (signal.aborted) return;
+        useProjectStore.setState({ currentProject: project });
+      } catch (err) {
+        if (isAbort(err)) return;
+        setLoadErrors((prev) => ({
+          ...prev,
+          project: describe(err, "加载项目详情失败"),
+        }));
       }
     };
+    const loadVersions = async () => {
+      try {
+        const versions = await api.listProjectVersions(id, { signal });
+        if (signal.aborted) return;
+        useProjectStore.setState({ versions });
+      } catch (err) {
+        if (isAbort(err)) return;
+        setLoadErrors((prev) => ({
+          ...prev,
+          versions: describe(err, "加载版本失败"),
+        }));
+      }
+    };
+    const loadRuns = async () => {
+      try {
+        const runs = await api.listProjectRuns(id, { signal });
+        if (signal.aborted) return;
+        useProjectStore.setState({ runs });
+      } catch (err) {
+        if (isAbort(err)) return;
+        setLoadErrors((prev) => ({
+          ...prev,
+          runs: describe(err, "加载运行记录失败"),
+        }));
+      }
+    };
+
+    const load = async () => {
+      await Promise.allSettled([loadProject(), loadVersions(), loadRuns()]);
+      if (signal.aborted) return;
+      setLoading(false);
+    };
     load();
-  }, [id, fetchProject, fetchVersions, fetchRuns]);
+
+    return () => controller.abort();
+  }, [id]);
 
   // Sync title and plan steps when project loads
   useEffect(() => {
@@ -373,8 +428,14 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailProps) {
 
   if (!currentProject) {
     return (
-      <div className="flex-1 p-6">
-        <p className="text-muted-foreground">未找到项目。</p>
+      <div className="flex-1 p-6 space-y-3">
+        {loadErrors.project ? (
+          <p className="text-sm text-destructive">
+            加载项目详情失败：{loadErrors.project}
+          </p>
+        ) : (
+          <p className="text-muted-foreground">未找到项目。</p>
+        )}
       </div>
     );
   }
@@ -383,8 +444,18 @@ export default function ProjectDetailPage({ projectId }: ProjectDetailProps) {
   const approvalStatus = (plan as any)?.approval_status as string | undefined;
   const activeRun = currentProject.active_run;
 
+  const nonFatalLoadErrors = [
+    loadErrors.versions ? `版本：${loadErrors.versions}` : null,
+    loadErrors.runs ? `运行记录：${loadErrors.runs}` : null,
+  ].filter(Boolean) as string[];
+
   return (
     <div className="flex flex-1 min-h-0 flex-col overflow-auto p-6">
+      {nonFatalLoadErrors.length > 0 && (
+        <div className="mb-4 border border-destructive/40 bg-destructive/10 text-destructive text-sm rounded-md px-3 py-2">
+          部分数据加载失败：{nonFatalLoadErrors.join("；")}
+        </div>
+      )}
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
         {!isInline && (

--- a/apps/web/features/projects/store.ts
+++ b/apps/web/features/projects/store.ts
@@ -18,14 +18,14 @@ interface ProjectState {
 
 interface ProjectActions {
   fetch: () => Promise<void>;
-  fetchProject: (id: string) => Promise<void>;
+  fetchProject: (id: string, signal?: AbortSignal) => Promise<void>;
   createProject: (data: { title: string; description?: string; schedule_type: string }) => Promise<Project>;
   createFromChat: (data: CreateProjectFromChatRequest) => Promise<Project>;
   updateProject: (id: string, data: Partial<Project>) => Promise<void>;
   deleteProject: (id: string) => Promise<void>;
   forkProject: (id: string, branchName: string, reason?: string) => Promise<void>;
-  fetchVersions: (id: string) => Promise<void>;
-  fetchRuns: (id: string) => Promise<void>;
+  fetchVersions: (id: string, signal?: AbortSignal) => Promise<void>;
+  fetchRuns: (id: string, signal?: AbortSignal) => Promise<void>;
   approvePlan: (projectId: string) => Promise<void>;
   rejectPlan: (projectId: string, reason: string) => Promise<void>;
 }
@@ -53,12 +53,14 @@ export const useProjectStore = create<ProjectState & ProjectActions>((set, get) 
     }
   },
 
-  fetchProject: async (id: string) => {
+  fetchProject: async (id: string, signal?: AbortSignal) => {
     logger.debug("fetch project", id);
     try {
-      const project = await api.getProject(id);
+      const project = await api.getProject(id, signal ? { signal } : undefined);
+      if (signal?.aborted) return;
       set({ currentProject: project });
     } catch (err) {
+      if ((err as Error)?.name === "AbortError") return;
       logger.error("fetch project failed", err);
       toast.error("加载项目详情失败");
     }
@@ -113,20 +115,24 @@ export const useProjectStore = create<ProjectState & ProjectActions>((set, get) 
     }
   },
 
-  fetchVersions: async (id) => {
+  fetchVersions: async (id, signal) => {
     try {
-      const versions = await api.listProjectVersions(id);
+      const versions = await api.listProjectVersions(id, signal ? { signal } : undefined);
+      if (signal?.aborted) return;
       set({ versions });
     } catch (err) {
+      if ((err as Error)?.name === "AbortError") return;
       logger.error("fetch versions failed", err);
     }
   },
 
-  fetchRuns: async (id) => {
+  fetchRuns: async (id, signal) => {
     try {
-      const runs = await api.listProjectRuns(id);
+      const runs = await api.listProjectRuns(id, signal ? { signal } : undefined);
+      if (signal?.aborted) return;
       set({ runs });
     } catch (err) {
+      if ((err as Error)?.name === "AbortError") return;
       logger.error("fetch runs failed", err);
     }
   },

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -832,8 +832,8 @@ export class ApiClient {
     return this.fetch('/api/projects');
   }
 
-  async getProject(id: string): Promise<Project> {
-    return this.fetch(`/api/projects/${id}`);
+  async getProject(id: string, init?: RequestInit): Promise<Project> {
+    return this.fetch(`/api/projects/${id}`, init);
   }
 
   async createProject(data: { title: string; description?: string; schedule_type: string }): Promise<Project> {
@@ -856,12 +856,12 @@ export class ApiClient {
     return this.fetch(`/api/projects/${id}/fork`, { method: 'POST', body: JSON.stringify(data) });
   }
 
-  async listProjectVersions(id: string): Promise<ProjectVersion[]> {
-    return this.fetch(`/api/projects/${id}/versions`);
+  async listProjectVersions(id: string, init?: RequestInit): Promise<ProjectVersion[]> {
+    return this.fetch(`/api/projects/${id}/versions`, init);
   }
 
-  async listProjectRuns(id: string): Promise<ProjectRun[]> {
-    return this.fetch(`/api/projects/${id}/runs`);
+  async listProjectRuns(id: string, init?: RequestInit): Promise<ProjectRun[]> {
+    return this.fetch(`/api/projects/${id}/runs`, init);
   }
 
   async approvePlan(projectId: string): Promise<void> {

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -5,19 +5,18 @@ test.describe("Authentication", () => {
   test("login page renders correctly", async ({ page }) => {
     await page.goto("/login");
 
-    await expect(page.locator("h1")).toContainText("Multica");
-    await expect(page.locator('input[placeholder="Email"]')).toBeVisible();
-    await expect(page.locator('input[placeholder="Name"]')).toBeVisible();
+    await expect(page.getByText("My Team")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "邮箱" })).toBeVisible();
     await expect(page.locator('button[type="submit"]')).toContainText(
-      "Sign in",
+      "继续",
     );
   });
 
-  test("login and redirect to /issues", async ({ page }) => {
+  test("login and redirect to /projects", async ({ page }) => {
     await loginAsDefault(page);
 
-    await expect(page).toHaveURL(/\/issues/);
-    await expect(page.locator("text=All Issues")).toBeVisible();
+    await expect(page).toHaveURL(/\/projects/);
+    await expect(page.getByRole("button", { name: "创建项目" })).toBeVisible();
   });
 
   test("unauthenticated user is redirected to /login", async ({ page }) => {
@@ -27,7 +26,7 @@ test.describe("Authentication", () => {
       localStorage.removeItem("multica_workspace_id");
     });
 
-    await page.goto("/issues");
+    await page.goto("/projects");
     await page.waitForURL("**/login", { timeout: 10000 });
   });
 
@@ -37,8 +36,7 @@ test.describe("Authentication", () => {
     // Open the workspace dropdown menu
     await openWorkspaceMenu(page);
 
-    // Click Sign out
-    await page.locator("text=Sign out").click();
+    await page.getByText("退出登录").click();
 
     await page.waitForURL("**/login", { timeout: 10000 });
     await expect(page).toHaveURL(/\/login/);

--- a/e2e/comments.spec.ts
+++ b/e2e/comments.spec.ts
@@ -1,56 +1,26 @@
 import { test, expect } from "@playwright/test";
-import { createTestApi, loginAsDefault } from "./helpers";
-import type { TestApiClient } from "./fixtures";
+import { loginAsDefault } from "./helpers";
 
 test.describe("Comments", () => {
-  let api: TestApiClient;
-
   test.beforeEach(async ({ page }) => {
-    api = await createTestApi();
-    await api.createIssue("E2E Comment Test " + Date.now());
     await loginAsDefault(page);
   });
 
-  test.afterEach(async () => {
-    await api.cleanup();
+  test("session page renders the current messaging shell", async ({ page }) => {
+    await page.goto("/session");
+    await page.waitForURL("**/session");
+
+    await expect(page.getByPlaceholder("搜索会话...")).toBeVisible();
+    await expect(page.getByRole("button", { name: "创建频道" })).toBeVisible();
+    await expect(page.getByText("选择一个对话")).toBeVisible();
   });
 
-  test("can add a comment on an issue", async ({ page }) => {
-    // Wait for issues to load and click first one
-    const issueLink = page.locator('a[href^="/issues/"]').first();
-    await expect(issueLink).toBeVisible({ timeout: 5000 });
-    await issueLink.click();
-    await page.waitForURL(/\/issues\/[\w-]+/);
+  test("create channel dialog opens from the session sidebar", async ({ page }) => {
+    await page.goto("/session");
+    await page.waitForURL("**/session");
 
-    // Wait for issue detail to load
-    await expect(page.locator("text=Properties")).toBeVisible();
-
-    // Type a comment
-    const commentText = "E2E comment " + Date.now();
-    const commentInput = page.locator(
-      'input[placeholder="Leave a comment..."]',
-    );
-    await commentInput.fill(commentText);
-
-    // Submit the comment
-    await page.locator('form button[type="submit"]').last().click();
-
-    // Comment should appear in the activity section
-    await expect(page.locator(`text=${commentText}`)).toBeVisible({
-      timeout: 5000,
-    });
-  });
-
-  test("comment submit button is disabled when empty", async ({ page }) => {
-    const issueLink = page.locator('a[href^="/issues/"]').first();
-    await expect(issueLink).toBeVisible({ timeout: 5000 });
-    await issueLink.click();
-    await page.waitForURL(/\/issues\/[\w-]+/);
-
-    await expect(page.locator("text=Properties")).toBeVisible();
-
-    // Submit button should be disabled when input is empty
-    const submitBtn = page.locator('form button[type="submit"]').last();
-    await expect(submitBtn).toBeDisabled();
+    await page.getByRole("button", { name: "创建频道" }).click();
+    await expect(page.getByRole("heading", { name: "创建频道" })).toBeVisible();
+    await expect(page.getByPlaceholder("频道名称")).toBeVisible();
   });
 });

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -15,10 +15,16 @@ interface TestWorkspace {
   slug: string;
 }
 
+interface TestProject {
+  id: string;
+  title: string;
+}
+
 export class TestApiClient {
   private token: string | null = null;
   private workspaceId: string | null = null;
   private createdIssueIds: string[] = [];
+  private createdProjectIds: string[] = [];
 
   async login(email: string, name: string) {
     // Step 1: Send verification code
@@ -72,7 +78,14 @@ export class TestApiClient {
 
   async getWorkspaces(): Promise<TestWorkspace[]> {
     const res = await this.authedFetch("/api/workspaces");
-    return res.json();
+    const data = await res.json();
+    if (Array.isArray(data)) {
+      return data as TestWorkspace[];
+    }
+    if (Array.isArray(data?.workspaces)) {
+      return data.workspaces as TestWorkspace[];
+    }
+    return [];
   }
 
   setWorkspaceId(id: string) {
@@ -117,8 +130,22 @@ export class TestApiClient {
     return issue;
   }
 
+  async createProject(title: string, opts?: Record<string, unknown>) {
+    const res = await this.authedFetch("/api/projects", {
+      method: "POST",
+      body: JSON.stringify({ title, ...opts }),
+    });
+    const project = (await res.json()) as TestProject;
+    this.createdProjectIds.push(project.id);
+    return project;
+  }
+
   async deleteIssue(id: string) {
     await this.authedFetch(`/api/issues/${id}`, { method: "DELETE" });
+  }
+
+  async deleteProject(id: string) {
+    await this.authedFetch(`/api/projects/${id}`, { method: "DELETE" });
   }
 
   /** Clean up all issues created during this test. */
@@ -131,10 +158,23 @@ export class TestApiClient {
       }
     }
     this.createdIssueIds = [];
+
+    for (const id of this.createdProjectIds) {
+      try {
+        await this.deleteProject(id);
+      } catch {
+        /* ignore — may already be deleted */
+      }
+    }
+    this.createdProjectIds = [];
   }
 
   getToken() {
     return this.token;
+  }
+
+  getWorkspaceId() {
+    return this.workspaceId;
   }
 
   private async authedFetch(path: string, init?: RequestInit) {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,43 +1,76 @@
 import { type Page } from "@playwright/test";
 import { TestApiClient } from "./fixtures";
 
-const DEFAULT_E2E_NAME = "E2E User";
-const DEFAULT_E2E_EMAIL = "e2e@multica.ai";
-const DEFAULT_E2E_WORKSPACE = "e2e-workspace";
+export interface E2EIdentity {
+  name: string;
+  email: string;
+  workspaceName: string;
+  workspaceSlug: string;
+}
+
+export function createE2EIdentity(label = "default"): E2EIdentity {
+  const suffix = `${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    name: `E2E User ${label}`,
+    email: `e2e+${suffix}@multica.ai`,
+    workspaceName: `E2E Workspace ${label}`,
+    workspaceSlug: `e2e-workspace-${suffix}`,
+  };
+}
 
 /**
  * Log in as the default E2E user and ensure the workspace exists first.
  * Authenticates via API (send-code → DB read → verify-code), then injects
  * the token into localStorage so the browser session is authenticated.
  */
-export async function loginAsDefault(page: Page) {
+export async function loginAsDefault(
+  page: Page,
+  identity: E2EIdentity = createE2EIdentity(),
+) {
   const api = new TestApiClient();
-  await api.login(DEFAULT_E2E_EMAIL, DEFAULT_E2E_NAME);
-  await api.ensureWorkspace("E2E Workspace", DEFAULT_E2E_WORKSPACE);
-
+  await api.login(identity.email, identity.name);
+  const workspace = await api.ensureWorkspace(
+    identity.workspaceName,
+    identity.workspaceSlug,
+  );
   const token = api.getToken();
+  if (!token) {
+    throw new Error(`Failed to obtain E2E token for ${identity.email}`);
+  }
+  await loginWithApi(page, token, workspace.id);
+}
+
+export async function loginWithApi(
+  page: Page,
+  token: string,
+  workspaceId: string,
+) {
   await page.goto("/login");
-  await page.evaluate((t) => {
-    localStorage.setItem("multica_token", t);
-  }, token);
-  await page.goto("/issues");
-  await page.waitForURL("**/issues", { timeout: 10000 });
+  await page.evaluate(
+    ({ nextToken, workspaceId }) => {
+      localStorage.setItem("multica_token", nextToken);
+      localStorage.setItem("multica_workspace_id", workspaceId);
+    },
+    { nextToken: token, workspaceId },
+  );
+  await page.goto("/projects");
+  await page.waitForURL("**/projects", { timeout: 10000 });
 }
 
 /**
  * Create a TestApiClient logged in as the default E2E user.
  * Call api.cleanup() in afterEach to remove test data created during the test.
  */
-export async function createTestApi(): Promise<TestApiClient> {
+export async function createTestApi(
+  identity: E2EIdentity = createE2EIdentity(),
+): Promise<TestApiClient> {
   const api = new TestApiClient();
-  await api.login(DEFAULT_E2E_EMAIL, DEFAULT_E2E_NAME);
-  await api.ensureWorkspace("E2E Workspace", DEFAULT_E2E_WORKSPACE);
+  await api.login(identity.email, identity.name);
+  await api.ensureWorkspace(identity.workspaceName, identity.workspaceSlug);
   return api;
 }
 
 export async function openWorkspaceMenu(page: Page) {
-  // Click the workspace switcher button (has ChevronDown icon)
-  await page.locator("aside button").first().click();
-  // Wait for dropdown to appear
-  await page.locator('[class*="popover"]').waitFor({ state: "visible" });
+  await page.locator('[data-slot="sidebar"]').getByRole("button").first().click();
+  await page.getByText("工作区").waitFor({ state: "visible" });
 }

--- a/e2e/issues.spec.ts
+++ b/e2e/issues.spec.ts
@@ -1,88 +1,40 @@
 import { test, expect } from "@playwright/test";
-import { loginAsDefault, createTestApi } from "./helpers";
+import {
+  createTestApi,
+  createE2EIdentity,
+  loginWithApi,
+} from "./helpers";
 import type { TestApiClient } from "./fixtures";
 
-test.describe("Issues", () => {
+test.describe("Projects", () => {
   let api: TestApiClient;
 
   test.beforeEach(async ({ page }) => {
-    api = await createTestApi();
-    await loginAsDefault(page);
+    const identity = createE2EIdentity("projects");
+    api = await createTestApi(identity);
+    await loginWithApi(page, api.getToken()!, api.getWorkspaceId()!);
   });
 
   test.afterEach(async () => {
     await api.cleanup();
   });
 
-  test("issues page loads with board view", async ({ page }) => {
-    await expect(page.locator("text=All Issues")).toBeVisible();
+  test("legacy /issues route redirects to /projects", async ({ page }) => {
+    await page.goto("/issues");
+    await page.waitForURL("**/projects");
 
-    // Board columns should be visible
-    await expect(page.locator("text=Backlog")).toBeVisible();
-    await expect(page.locator("text=Todo")).toBeVisible();
-    await expect(page.locator("text=In Progress")).toBeVisible();
+    await expect(page.getByRole("button", { name: "创建项目" })).toBeVisible();
+    await expect(page.getByText("选择一个项目")).toBeVisible();
   });
 
-  test("can switch between board and list view", async ({ page }) => {
-    await expect(page.locator("text=All Issues")).toBeVisible();
+  test("can open a project from the list and render inline detail", async ({ page }) => {
+    const project = await api.createProject("E2E Project " + Date.now());
 
-    // Switch to list view
-    await page.click("text=List");
-    await expect(page.locator("text=All Issues")).toBeVisible();
+    await page.goto("/projects");
+    await expect(page.getByText(project.title).first()).toBeVisible({ timeout: 10000 });
 
-    // Switch back to board view
-    await page.click("text=Board");
-    await expect(page.locator("text=Backlog")).toBeVisible();
-  });
-
-  test("can create a new issue", async ({ page }) => {
-    await page.click("text=New Issue");
-
-    const title = "E2E Created " + Date.now();
-    await page.fill('input[placeholder="Issue title..."]', title);
-    await page.click("text=Create");
-
-    // New issue should appear on the page
-    await expect(page.locator(`text=${title}`).first()).toBeVisible({
-      timeout: 10000,
-    });
-  });
-
-  test("can navigate to issue detail page", async ({ page }) => {
-    // Create a known issue via API so the test controls its own fixture
-    const issue = await api.createIssue("E2E Detail Test " + Date.now());
-
-    // Reload to see the new issue
-    await page.reload();
-    await expect(page.locator("text=All Issues")).toBeVisible();
-
-    // Navigate to the issue detail
-    const issueLink = page.locator(`a[href="/issues/${issue.id}"]`);
-    await expect(issueLink).toBeVisible({ timeout: 5000 });
-    await issueLink.click();
-
-    await page.waitForURL(/\/issues\/[\w-]+/);
-
-    // Should show Properties panel
-    await expect(page.locator("text=Properties")).toBeVisible();
-    // Should show breadcrumb link back to Issues
-    await expect(
-      page.locator("a", { hasText: "Issues" }).first(),
-    ).toBeVisible();
-  });
-
-  test("can cancel issue creation", async ({ page }) => {
-    await page.click("text=New Issue");
-
-    await expect(
-      page.locator('input[placeholder="Issue title..."]'),
-    ).toBeVisible();
-
-    await page.click("text=Cancel");
-
-    await expect(
-      page.locator('input[placeholder="Issue title..."]'),
-    ).not.toBeVisible();
-    await expect(page.locator("text=New Issue")).toBeVisible();
+    await page.getByText(project.title).first().click();
+    await expect(page.getByRole("heading", { name: project.title })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("button", { name: "批准计划" })).toBeVisible();
   });
 });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -7,37 +7,41 @@ test.describe("Navigation", () => {
   });
 
   test("sidebar navigation works", async ({ page }) => {
-    // Click Inbox
-    await page.locator("nav a", { hasText: "Inbox" }).click();
-    await page.waitForURL("**/inbox");
-    await expect(page).toHaveURL(/\/inbox/);
+    await page.getByRole("link", { name: "会话" }).click();
+    await page.waitForURL("**/session");
+    await expect(page.getByPlaceholder("搜索会话...")).toBeVisible();
 
-    // Click Agents
-    await page.locator("nav a", { hasText: "Agents" }).click();
-    await page.waitForURL("**/agents");
-    await expect(page).toHaveURL(/\/agents/);
+    await page.getByRole("link", { name: "项目" }).click();
+    await page.waitForURL("**/projects");
+    await expect(page.getByRole("button", { name: "创建项目" })).toBeVisible();
 
-    // Click Issues
-    await page.locator("nav a", { hasText: "Issues" }).click();
-    await page.waitForURL("**/issues");
-    await expect(page).toHaveURL(/\/issues/);
-  });
+    await page.getByRole("link", { name: "文件" }).click();
+    await page.waitForURL("**/files");
+    await expect(page.getByRole("heading", { name: /文件/ })).toBeVisible();
 
-  test("settings page loads via workspace menu", async ({ page }) => {
-    // Settings is inside the workspace dropdown menu
-    await openWorkspaceMenu(page);
-    await page.locator("text=Settings").click();
+    await page.getByRole("link", { name: "身份" }).click();
+    await page.waitForURL("**/account");
+    await expect(page.getByRole("heading", { name: "概览", exact: true })).toBeVisible();
+
+    await page.getByRole("link", { name: "设置" }).click();
     await page.waitForURL("**/settings");
-
-    await expect(page.getByRole("heading", { name: "Workspace" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Members" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "设置" })).toBeVisible();
   });
 
-  test("agents page shows agent list", async ({ page }) => {
-    await page.locator("nav a", { hasText: "Agents" }).click();
-    await page.waitForURL("**/agents");
+  test("workspace menu opens current workspace controls", async ({ page }) => {
+    await openWorkspaceMenu(page);
 
-    // Should show "Agents" heading
-    await expect(page.locator("text=Agents").first()).toBeVisible();
+    await expect(page.getByText("工作区")).toBeVisible();
+    await expect(page.getByText("退出登录")).toBeVisible();
+  });
+
+  test("session page can open and close the create channel dialog", async ({ page }) => {
+    await page.goto("/session");
+    await page.waitForURL("**/session");
+
+    await page.getByRole("button", { name: "创建频道" }).click();
+    await expect(page.getByPlaceholder("频道名称")).toBeVisible();
+    await page.getByRole("button", { name: "取消" }).click();
+    await expect(page.getByPlaceholder("频道名称")).not.toBeVisible();
   });
 });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { loginAsDefault, openWorkspaceMenu } from "./helpers";
+import { loginAsDefault } from "./helpers";
 
 test.describe("Settings", () => {
   test("updating workspace name reflects in sidebar immediately", async ({
@@ -7,36 +7,26 @@ test.describe("Settings", () => {
   }) => {
     await loginAsDefault(page);
 
-    // Read the current workspace name from the sidebar
-    const sidebarName = page.locator("aside button").first();
-    const originalName = await sidebarName.innerText();
-
-    // Navigate to settings
-    await openWorkspaceMenu(page);
-    await page.locator("text=Settings").click();
+    await page.goto("/settings");
     await page.waitForURL("**/settings");
+    await page.getByRole("tab", { name: "通用" }).click();
 
-    // Change workspace name
     const nameInput = page
-      .locator('input[type="text"]')
-      .first();
+      .locator('label:has-text("名称")')
+      .locator("..")
+      .locator("input");
+    const originalName = (await nameInput.inputValue()).trim();
     await nameInput.clear();
     const newName = "Renamed WS " + Date.now();
     await nameInput.fill(newName);
 
-    // Save
-    await page.locator("button", { hasText: "Save" }).click();
+    await page.getByRole("button", { name: "保存" }).click();
+    await expect(page.getByText("工作区设置已保存").first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-slot="sidebar"]').getByText(newName)).toBeVisible();
 
-    // Wait for "Saved!" confirmation
-    await expect(page.locator("text=Saved!")).toBeVisible({ timeout: 5000 });
-
-    // Sidebar should reflect the new name WITHOUT page refresh
-    await expect(sidebarName).toContainText(newName);
-
-    // Restore original name so other tests aren't affected
     await nameInput.clear();
-    await nameInput.fill(originalName.trim());
-    await page.locator("button", { hasText: "Save" }).click();
-    await expect(page.locator("text=Saved!")).toBeVisible({ timeout: 5000 });
+    await nameInput.fill(originalName);
+    await page.getByRole("button", { name: "保存" }).click();
+    await expect(page.getByText("工作区设置已保存").first()).toBeVisible({ timeout: 5000 });
   });
 });

--- a/server/internal/handler/activity_log_test.go
+++ b/server/internal/handler/activity_log_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 // activityCleanup deletes any activity_log rows linked to the given
@@ -237,14 +239,22 @@ func TestListActivityLog_ByTask(t *testing.T) {
 }
 
 // requestAs builds a request with a custom X-User-ID header (overriding the
-// owner default supplied by newRequest).
+// owner default supplied by newRequest). Also injects the workspace member
+// context so resolveWorkspaceID (which reads only context after the #20 fix)
+// resolves correctly for the impersonated user.
 func requestAs(t *testing.T, userID, method, path string) *http.Request {
 	t.Helper()
 	req := httptest.NewRequest(method, path, nil)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-User-ID", userID)
-	req.Header.Set("X-Workspace-ID", testWorkspaceID)
-	return req
+	member, err := testHandler.Queries.GetMemberByUserAndWorkspace(req.Context(), db.GetMemberByUserAndWorkspaceParams{
+		UserID:      parseUUID(userID),
+		WorkspaceID: parseUUID(testWorkspaceID),
+	})
+	if err != nil {
+		t.Fatalf("requestAs: member lookup for user %s failed: %v", userID, err)
+	}
+	return req.WithContext(middleware.SetMemberContext(req.Context(), testWorkspaceID, member))
 }
 
 // listActivityProjectIDs decodes the entries response and returns the

--- a/server/internal/handler/daemon_executions.go
+++ b/server/internal/handler/daemon_executions.go
@@ -77,8 +77,7 @@ func (h *Handler) ClaimExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req claimExecutionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		writeError(w, http.StatusBadRequest, "invalid body")
+	if !decodeRequestJSONOptional(w, r, &req) {
 		return
 	}
 
@@ -158,8 +157,7 @@ func (h *Handler) StartExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req startExecutionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		writeError(w, http.StatusBadRequest, "invalid body")
+	if !decodeRequestJSONOptional(w, r, &req) {
 		return
 	}
 
@@ -206,8 +204,7 @@ func (h *Handler) ProgressExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req progressExecutionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		writeError(w, http.StatusBadRequest, "invalid body")
+	if !decodeRequestJSON(w, r, &req) {
 		return
 	}
 
@@ -245,8 +242,7 @@ func (h *Handler) CompleteExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req completeExecutionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid body")
+	if !decodeRequestJSON(w, r, &req) {
 		return
 	}
 
@@ -327,8 +323,7 @@ func (h *Handler) FailExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req failExecutionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		writeError(w, http.StatusBadRequest, "invalid body")
+	if !decodeRequestJSONOptional(w, r, &req) {
 		return
 	}
 	if req.Status == "" {
@@ -393,8 +388,7 @@ func (h *Handler) StreamExecutionMessage(w http.ResponseWriter, r *http.Request)
 	}
 
 	var req executionMessageRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
-		writeError(w, http.StatusBadRequest, "invalid body")
+	if !decodeRequestJSON(w, r, &req) {
 		return
 	}
 
@@ -409,6 +403,35 @@ func (h *Handler) StreamExecutionMessage(w http.ResponseWriter, r *http.Request)
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
+
+func decodeRequestJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(dst); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return false
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return false
+	}
+	return true
+}
+
+func decodeRequestJSONOptional(w http.ResponseWriter, r *http.Request, dst any) bool {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(dst); err != nil {
+		if errors.Is(err, io.EOF) {
+			return true
+		}
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return false
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return false
+	}
+	return true
+}
 
 // publishExecutionEvent fans out an execution-scoped WS event when the
 // event bus is wired. Bus is optional so tests that bypass it remain
@@ -438,19 +461,19 @@ func (h *Handler) publishExecutionEvent(r *http.Request, eventType string, execu
 // daemon never has to inspect pgtype.* sentinel structs.
 func executionToResponse(e db.Execution) map[string]any {
 	out := map[string]any{
-		"id":         uuid.UUID(e.ID.Bytes).String(),
-		"task_id":    uuid.UUID(e.TaskID.Bytes).String(),
-		"run_id":     uuid.UUID(e.RunID.Bytes).String(),
-		"agent_id":   uuid.UUID(e.AgentID.Bytes).String(),
-		"runtime_id": uuid.UUID(e.RuntimeID.Bytes).String(),
-		"attempt":    e.Attempt,
-		"status":     e.Status,
-		"priority":   e.Priority,
-		"payload":    rawJSONOrEmpty(e.Payload),
-		"result":     rawJSONOrEmpty(e.Result),
-		"context_ref": rawJSONOrEmpty(e.ContextRef),
-		"cost_input_tokens":  e.CostInputTokens,
-		"cost_output_tokens": e.CostOutputTokens,
+		"id":                   uuid.UUID(e.ID.Bytes).String(),
+		"task_id":              uuid.UUID(e.TaskID.Bytes).String(),
+		"run_id":               uuid.UUID(e.RunID.Bytes).String(),
+		"agent_id":             uuid.UUID(e.AgentID.Bytes).String(),
+		"runtime_id":           uuid.UUID(e.RuntimeID.Bytes).String(),
+		"attempt":              e.Attempt,
+		"status":               e.Status,
+		"priority":             e.Priority,
+		"payload":              rawJSONOrEmpty(e.Payload),
+		"result":               rawJSONOrEmpty(e.Result),
+		"context_ref":          rawJSONOrEmpty(e.ContextRef),
+		"cost_input_tokens":    e.CostInputTokens,
+		"cost_output_tokens":   e.CostOutputTokens,
 		"log_retention_policy": e.LogRetentionPolicy,
 	}
 	if e.SlotID.Valid {

--- a/server/internal/handler/daemon_executions.go
+++ b/server/internal/handler/daemon_executions.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -76,7 +77,10 @@ func (h *Handler) ClaimExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req claimExecutionRequest
-	_ = json.NewDecoder(r.Body).Decode(&req)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
 
 	// Default working_dir from the runtime row when the daemon doesn't
 	// supply one (e.g. cloud executor poll). Look up the runtime so we can
@@ -84,7 +88,7 @@ func (h *Handler) ClaimExecution(w http.ResponseWriter, r *http.Request) {
 	mode := "local"
 	if req.WorkingDir == "" || req.DaemonID == "" || mode == "" {
 		rt, rtErr := h.Queries.GetAgentRuntime(r.Context(), pgUUIDFrom(runtimeID))
-		if rtErr == nil {
+		if rtErr == nil && rt.ID.Valid {
 			if req.WorkingDir == "" && rt.WorkingDir != "" {
 				req.WorkingDir = rt.WorkingDir
 			}
@@ -97,11 +101,17 @@ func (h *Handler) ClaimExecution(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	contextRef, _ := json.Marshal(map[string]any{
+	contextRef, err := json.Marshal(map[string]any{
 		"mode":        mode,
 		"working_dir": req.WorkingDir,
 		"daemon_id":   req.DaemonID,
 	})
+	if err != nil {
+		slog.Warn("execution claim context_ref encode failed",
+			"runtime_id", runtimeID, "err", err)
+		writeError(w, http.StatusInternalServerError, "encode failed")
+		return
+	}
 
 	e, err := h.Queries.ClaimExecution(r.Context(), db.ClaimExecutionParams{
 		RuntimeID:  pgUUIDFrom(runtimeID),
@@ -148,11 +158,20 @@ func (h *Handler) StartExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req startExecutionRequest
-	_ = json.NewDecoder(r.Body).Decode(&req)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
 
 	var ctxRefJSON []byte
 	if req.ContextRef != nil {
-		ctxRefJSON, _ = json.Marshal(req.ContextRef)
+		ctxRefJSON, err = json.Marshal(req.ContextRef)
+		if err != nil {
+			slog.Warn("execution start context_ref encode failed",
+				"execution_id", id, "err", err)
+			writeError(w, http.StatusInternalServerError, "encode failed")
+			return
+		}
 	}
 
 	if err := h.Queries.StartExecution(r.Context(), db.StartExecutionParams{
@@ -187,7 +206,10 @@ func (h *Handler) ProgressExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req progressExecutionRequest
-	_ = json.NewDecoder(r.Body).Decode(&req)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
 
 	h.publishExecutionEvent(r, "execution:progress", id, map[string]any{
 		"execution_id": id.String(),
@@ -305,7 +327,10 @@ func (h *Handler) FailExecution(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req failExecutionRequest
-	_ = json.NewDecoder(r.Body).Decode(&req)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
 	if req.Status == "" {
 		req.Status = "failed"
 	}
@@ -368,7 +393,10 @@ func (h *Handler) StreamExecutionMessage(w http.ResponseWriter, r *http.Request)
 	}
 
 	var req executionMessageRequest
-	_ = json.NewDecoder(r.Body).Decode(&req)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
 
 	h.publishExecutionEvent(r, "execution:message", id, map[string]any{
 		"execution_id": id.String(),

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -195,16 +194,16 @@ func requireUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	return userID, true
 }
 
+// resolveWorkspaceID returns the workspace ID from the middleware-validated
+// request context. Query-param and X-Workspace-ID-header fallbacks were
+// removed: both sources accepted user-supplied values without a membership
+// check, so a route that accidentally bypassed RequireWorkspaceMember would
+// trust them blindly. All production workspace routes run through the
+// middleware, which validates membership before injecting the workspace ID
+// into the context (see internal/middleware/workspace.go buildMiddleware).
+// Tests must inject the context explicitly via middleware.SetMemberContext.
 func resolveWorkspaceID(r *http.Request) string {
-	// Prefer context value set by workspace middleware.
-	if id := middleware.WorkspaceIDFromContext(r.Context()); id != "" {
-		return id
-	}
-	workspaceID := r.URL.Query().Get("workspace_id")
-	if workspaceID != "" {
-		return workspaceID
-	}
-	return r.Header.Get("X-Workspace-ID")
+	return middleware.WorkspaceIDFromContext(r.Context())
 }
 
 // ctxMember returns the workspace member from context (set by workspace middleware).
@@ -217,12 +216,13 @@ func ctxWorkspaceID(ctx context.Context) string {
 	return middleware.WorkspaceIDFromContext(ctx)
 }
 
-// workspaceIDFromURL returns the workspace ID from context (preferred) or chi URL param (fallback).
-func workspaceIDFromURL(r *http.Request, param string) string {
-	if id := middleware.WorkspaceIDFromContext(r.Context()); id != "" {
-		return id
-	}
-	return chi.URLParam(r, param)
+// workspaceIDFromURL returns the workspace ID from the middleware-validated
+// request context. The chi URL-param fallback was removed: the URL param is
+// user-controlled and only safe after RequireWorkspaceMemberFromURL has run
+// and written the validated workspace ID into the context. The param argument
+// is retained for call-site ergonomics but is no longer read.
+func workspaceIDFromURL(r *http.Request, _ string) string {
+	return middleware.WorkspaceIDFromContext(r.Context())
 }
 
 // workspaceMember returns the member from middleware context, or falls back to a DB

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/realtime"
 	"github.com/multica-ai/multica/server/internal/service"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -23,6 +24,7 @@ var testHandler *Handler
 var testPool *pgxpool.Pool
 var testUserID string
 var testWorkspaceID string
+var testMember db.Member
 
 const (
 	handlerTestEmail         = "handler-test@multica.ai"
@@ -59,6 +61,16 @@ func TestMain(m *testing.M) {
 	testUserID, testWorkspaceID, err = setupHandlerTestFixture(ctx, pool)
 	if err != nil {
 		fmt.Printf("Failed to set up handler test fixture: %v\n", err)
+		pool.Close()
+		os.Exit(1)
+	}
+
+	testMember, err = queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
+		UserID:      parseUUID(testUserID),
+		WorkspaceID: parseUUID(testWorkspaceID),
+	})
+	if err != nil {
+		fmt.Printf("Failed to load test member: %v\n", err)
 		pool.Close()
 		os.Exit(1)
 	}
@@ -147,8 +159,10 @@ func newRequest(method, path string, body any) *http.Request {
 	req := httptest.NewRequest(method, path, &buf)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-User-ID", testUserID)
-	req.Header.Set("X-Workspace-ID", testWorkspaceID)
-	return req
+	// resolveWorkspaceID now reads only the middleware-injected context, so
+	// tests must inject the same context the workspace middleware would
+	// produce in production.
+	return req.WithContext(middleware.SetMemberContext(req.Context(), testWorkspaceID, testMember))
 }
 
 func withURLParam(req *http.Request, key, value string) *http.Request {

--- a/server/internal/handler/meeting_audio_test.go
+++ b/server/internal/handler/meeting_audio_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/multica-ai/multica/server/internal/middleware"
 )
 
 // TestIsAllowedAudioMIME — whitelist gate for the audio upload endpoint.
@@ -59,7 +61,9 @@ func TestUploadMeetingAudio_RejectsBadMIME(t *testing.T) {
 	req = httptest.NewRequest("POST", "/api/threads/"+fx.threadID+"/meeting/audio", body)
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-User-ID", testUserID)
-	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	// resolveWorkspaceID reads only the middleware-injected context after
+	// the #20 fix; mirror that here since this request bypasses newRequest.
+	req = req.WithContext(middleware.SetMemberContext(req.Context(), testWorkspaceID, testMember))
 	req = withURLParam(req, "threadID", fx.threadID)
 	testHandler.UploadMeetingAudio(w, req)
 	if w.Code != http.StatusUnsupportedMediaType {

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -94,8 +94,8 @@ func projectToResponse(p db.Project) ProjectResponse {
 	return resp
 }
 
-// projectVersionToResponse maps a db.ProjectVersion row to the JSON shape.
-func projectVersionToResponse(v db.ProjectVersion) ProjectVersionResponse {
+// projectVersionToResponse maps the current list query shape to the JSON response.
+func projectVersionToResponse(v db.ListProjectVersionsRow) ProjectVersionResponse {
 	resp := ProjectVersionResponse{
 		ID:            uuidToString(v.ID),
 		ProjectID:     uuidToString(v.ProjectID),

--- a/server/internal/handler/project_versions_test.go
+++ b/server/internal/handler/project_versions_test.go
@@ -1,0 +1,139 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func insertProjectVersionFixture(t *testing.T, projectID string) string {
+	t.Helper()
+
+	ctx := context.Background()
+	rows, err := testPool.Query(ctx, `
+		SELECT column_name
+		FROM information_schema.columns
+		WHERE table_name = 'project_version'
+	`)
+	if err != nil {
+		t.Fatalf("load project_version columns: %v", err)
+	}
+	defer rows.Close()
+
+	columns := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan project_version column: %v", err)
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate project_version columns: %v", err)
+	}
+
+	insertColumns := []string{"project_id"}
+	values := []any{projectID}
+	if columns["created_by"] {
+		insertColumns = append(insertColumns, "created_by")
+		values = append(values, testUserID)
+	}
+	if columns["version_number"] {
+		insertColumns = append(insertColumns, "version_number")
+		values = append(values, 1)
+	}
+	if columns["branch_name"] {
+		insertColumns = append(insertColumns, "branch_name")
+		values = append(values, "main")
+	}
+	if columns["fork_reason"] {
+		insertColumns = append(insertColumns, "fork_reason")
+		values = append(values, "regression-test")
+	}
+	if columns["version_status"] {
+		insertColumns = append(insertColumns, "version_status")
+		values = append(values, "active")
+	}
+	if columns["version"] {
+		insertColumns = append(insertColumns, "version")
+		values = append(values, 1)
+	}
+	if columns["title"] {
+		insertColumns = append(insertColumns, "title")
+		values = append(values, "Version 1")
+	}
+	if columns["description"] {
+		insertColumns = append(insertColumns, "description")
+		values = append(values, "Project version fixture")
+	}
+
+	placeholders := make([]string, len(values))
+	for i := range values {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+	}
+
+	var versionID string
+	query := fmt.Sprintf(
+		`INSERT INTO project_version (%s) VALUES (%s) RETURNING id`,
+		strings.Join(insertColumns, ", "),
+		strings.Join(placeholders, ", "),
+	)
+	if err := testPool.QueryRow(ctx, query, values...).Scan(&versionID); err != nil {
+		t.Fatalf("insert project version fixture: %v", err)
+	}
+	return versionID
+}
+
+func TestListProjectVersions(t *testing.T) {
+	ctx := context.Background()
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title, description, status, created_by, schedule_type, source_conversations, creator_owner_id)
+		VALUES ($1, $2, '', 'not_started', $3, 'one_time', '[]'::jsonb, $3)
+		RETURNING id
+	`, testWorkspaceID, "Project Versions Test", testUserID).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID); err != nil {
+			t.Fatalf("cleanup project: %v", err)
+		}
+	})
+
+	insertProjectVersionFixture(t, projectID)
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/projects/"+projectID+"/versions", nil)
+	req = withURLParam(req, "projectID", projectID)
+	testHandler.ListProjectVersions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListProjectVersions: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Total    int                      `json:"total"`
+		Versions []ProjectVersionResponse `json:"versions"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Fatalf("ListProjectVersions: want total=1, got %d", resp.Total)
+	}
+	if len(resp.Versions) != 1 {
+		t.Fatalf("ListProjectVersions: want 1 version, got %d", len(resp.Versions))
+	}
+	if resp.Versions[0].ProjectID != projectID {
+		t.Fatalf("ListProjectVersions: want project_id=%s, got %s", projectID, resp.Versions[0].ProjectID)
+	}
+	if resp.Versions[0].VersionNumber != 1 {
+		t.Fatalf("ListProjectVersions: want version_number=1, got %d", resp.Versions[0].VersionNumber)
+	}
+}

--- a/server/pkg/db/generated/project_versions.sql.go
+++ b/server/pkg/db/generated/project_versions.sql.go
@@ -105,32 +105,52 @@ func (q *Queries) GetProjectVersion(ctx context.Context, id pgtype.UUID) (Projec
 }
 
 const listProjectVersions = `-- name: ListProjectVersions :many
-SELECT id, project_id, version, title, description, created_by, created_at, parent_version_id, version_number, branch_name, fork_reason, version_status, context_imports FROM project_version WHERE project_id = $1 ORDER BY version_number DESC
+SELECT
+    id,
+    project_id,
+    parent_version_id,
+    version_number,
+    branch_name,
+    fork_reason,
+    version_status,
+    created_by,
+    created_at
+FROM project_version
+WHERE project_id = $1
+ORDER BY version_number DESC
 `
 
-func (q *Queries) ListProjectVersions(ctx context.Context, projectID pgtype.UUID) ([]ProjectVersion, error) {
+type ListProjectVersionsRow struct {
+	ID              pgtype.UUID        `json:"id"`
+	ProjectID       pgtype.UUID        `json:"project_id"`
+	ParentVersionID pgtype.UUID        `json:"parent_version_id"`
+	VersionNumber   int32              `json:"version_number"`
+	BranchName      pgtype.Text        `json:"branch_name"`
+	ForkReason      pgtype.Text        `json:"fork_reason"`
+	VersionStatus   string             `json:"version_status"`
+	CreatedBy       pgtype.UUID        `json:"created_by"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+}
+
+func (q *Queries) ListProjectVersions(ctx context.Context, projectID pgtype.UUID) ([]ListProjectVersionsRow, error) {
 	rows, err := q.db.Query(ctx, listProjectVersions, projectID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ProjectVersion{}
+	items := []ListProjectVersionsRow{}
 	for rows.Next() {
-		var i ProjectVersion
+		var i ListProjectVersionsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.ProjectID,
-			&i.Version,
-			&i.Title,
-			&i.Description,
-			&i.CreatedBy,
-			&i.CreatedAt,
 			&i.ParentVersionID,
 			&i.VersionNumber,
 			&i.BranchName,
 			&i.ForkReason,
 			&i.VersionStatus,
-			&i.ContextImports,
+			&i.CreatedBy,
+			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/generated/project_versions.sql.go
+++ b/server/pkg/db/generated/project_versions.sql.go
@@ -14,7 +14,17 @@ import (
 const createProjectVersion = `-- name: CreateProjectVersion :one
 INSERT INTO project_version (project_id, parent_version_id, version_number, branch_name, fork_reason, created_by)
 VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, project_id, version, title, description, created_by, created_at, parent_version_id, version_number, branch_name, fork_reason, version_status, context_imports
+RETURNING
+    id,
+    project_id,
+    parent_version_id,
+    version_number,
+    branch_name,
+    fork_reason,
+    version_status,
+    created_by,
+    created_at,
+    context_imports
 `
 
 type CreateProjectVersionParams struct {
@@ -26,7 +36,20 @@ type CreateProjectVersionParams struct {
 	CreatedBy       pgtype.UUID `json:"created_by"`
 }
 
-func (q *Queries) CreateProjectVersion(ctx context.Context, arg CreateProjectVersionParams) (ProjectVersion, error) {
+type CreateProjectVersionRow struct {
+	ID              pgtype.UUID        `json:"id"`
+	ProjectID       pgtype.UUID        `json:"project_id"`
+	ParentVersionID pgtype.UUID        `json:"parent_version_id"`
+	VersionNumber   int32              `json:"version_number"`
+	BranchName      pgtype.Text        `json:"branch_name"`
+	ForkReason      pgtype.Text        `json:"fork_reason"`
+	VersionStatus   string             `json:"version_status"`
+	CreatedBy       pgtype.UUID        `json:"created_by"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	ContextImports  []byte             `json:"context_imports"`
+}
+
+func (q *Queries) CreateProjectVersion(ctx context.Context, arg CreateProjectVersionParams) (CreateProjectVersionRow, error) {
 	row := q.db.QueryRow(ctx, createProjectVersion,
 		arg.ProjectID,
 		arg.ParentVersionID,
@@ -35,70 +58,113 @@ func (q *Queries) CreateProjectVersion(ctx context.Context, arg CreateProjectVer
 		arg.ForkReason,
 		arg.CreatedBy,
 	)
-	var i ProjectVersion
+	var i CreateProjectVersionRow
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
-		&i.Version,
-		&i.Title,
-		&i.Description,
-		&i.CreatedBy,
-		&i.CreatedAt,
 		&i.ParentVersionID,
 		&i.VersionNumber,
 		&i.BranchName,
 		&i.ForkReason,
 		&i.VersionStatus,
+		&i.CreatedBy,
+		&i.CreatedAt,
 		&i.ContextImports,
 	)
 	return i, err
 }
 
 const getLatestProjectVersion = `-- name: GetLatestProjectVersion :one
-SELECT id, project_id, version, title, description, created_by, created_at, parent_version_id, version_number, branch_name, fork_reason, version_status, context_imports FROM project_version WHERE project_id = $1 ORDER BY version_number DESC LIMIT 1
+SELECT
+    id,
+    project_id,
+    parent_version_id,
+    version_number,
+    branch_name,
+    fork_reason,
+    version_status,
+    created_by,
+    created_at,
+    context_imports
+FROM project_version
+WHERE project_id = $1
+ORDER BY version_number DESC
+LIMIT 1
 `
 
-func (q *Queries) GetLatestProjectVersion(ctx context.Context, projectID pgtype.UUID) (ProjectVersion, error) {
+type GetLatestProjectVersionRow struct {
+	ID              pgtype.UUID        `json:"id"`
+	ProjectID       pgtype.UUID        `json:"project_id"`
+	ParentVersionID pgtype.UUID        `json:"parent_version_id"`
+	VersionNumber   int32              `json:"version_number"`
+	BranchName      pgtype.Text        `json:"branch_name"`
+	ForkReason      pgtype.Text        `json:"fork_reason"`
+	VersionStatus   string             `json:"version_status"`
+	CreatedBy       pgtype.UUID        `json:"created_by"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	ContextImports  []byte             `json:"context_imports"`
+}
+
+func (q *Queries) GetLatestProjectVersion(ctx context.Context, projectID pgtype.UUID) (GetLatestProjectVersionRow, error) {
 	row := q.db.QueryRow(ctx, getLatestProjectVersion, projectID)
-	var i ProjectVersion
+	var i GetLatestProjectVersionRow
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
-		&i.Version,
-		&i.Title,
-		&i.Description,
-		&i.CreatedBy,
-		&i.CreatedAt,
 		&i.ParentVersionID,
 		&i.VersionNumber,
 		&i.BranchName,
 		&i.ForkReason,
 		&i.VersionStatus,
+		&i.CreatedBy,
+		&i.CreatedAt,
 		&i.ContextImports,
 	)
 	return i, err
 }
 
 const getProjectVersion = `-- name: GetProjectVersion :one
-SELECT id, project_id, version, title, description, created_by, created_at, parent_version_id, version_number, branch_name, fork_reason, version_status, context_imports FROM project_version WHERE id = $1
+SELECT
+    id,
+    project_id,
+    parent_version_id,
+    version_number,
+    branch_name,
+    fork_reason,
+    version_status,
+    created_by,
+    created_at,
+    context_imports
+FROM project_version
+WHERE id = $1
 `
 
-func (q *Queries) GetProjectVersion(ctx context.Context, id pgtype.UUID) (ProjectVersion, error) {
+type GetProjectVersionRow struct {
+	ID              pgtype.UUID        `json:"id"`
+	ProjectID       pgtype.UUID        `json:"project_id"`
+	ParentVersionID pgtype.UUID        `json:"parent_version_id"`
+	VersionNumber   int32              `json:"version_number"`
+	BranchName      pgtype.Text        `json:"branch_name"`
+	ForkReason      pgtype.Text        `json:"fork_reason"`
+	VersionStatus   string             `json:"version_status"`
+	CreatedBy       pgtype.UUID        `json:"created_by"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	ContextImports  []byte             `json:"context_imports"`
+}
+
+func (q *Queries) GetProjectVersion(ctx context.Context, id pgtype.UUID) (GetProjectVersionRow, error) {
 	row := q.db.QueryRow(ctx, getProjectVersion, id)
-	var i ProjectVersion
+	var i GetProjectVersionRow
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
-		&i.Version,
-		&i.Title,
-		&i.Description,
-		&i.CreatedBy,
-		&i.CreatedAt,
 		&i.ParentVersionID,
 		&i.VersionNumber,
 		&i.BranchName,
 		&i.ForkReason,
 		&i.VersionStatus,
+		&i.CreatedBy,
+		&i.CreatedAt,
 		&i.ContextImports,
 	)
 	return i, err

--- a/server/pkg/db/queries/project_versions.sql
+++ b/server/pkg/db/queries/project_versions.sql
@@ -1,7 +1,17 @@
 -- name: CreateProjectVersion :one
 INSERT INTO project_version (project_id, parent_version_id, version_number, branch_name, fork_reason, created_by)
 VALUES (@project_id, @parent_version_id, @version_number, @branch_name, @fork_reason, @created_by)
-RETURNING *;
+RETURNING
+    id,
+    project_id,
+    parent_version_id,
+    version_number,
+    branch_name,
+    fork_reason,
+    version_status,
+    created_by,
+    created_at,
+    context_imports;
 
 -- name: ListProjectVersions :many
 SELECT
@@ -19,7 +29,33 @@ WHERE project_id = @project_id
 ORDER BY version_number DESC;
 
 -- name: GetProjectVersion :one
-SELECT * FROM project_version WHERE id = @id;
+SELECT
+    id,
+    project_id,
+    parent_version_id,
+    version_number,
+    branch_name,
+    fork_reason,
+    version_status,
+    created_by,
+    created_at,
+    context_imports
+FROM project_version
+WHERE id = @id;
 
 -- name: GetLatestProjectVersion :one
-SELECT * FROM project_version WHERE project_id = @project_id ORDER BY version_number DESC LIMIT 1;
+SELECT
+    id,
+    project_id,
+    parent_version_id,
+    version_number,
+    branch_name,
+    fork_reason,
+    version_status,
+    created_by,
+    created_at,
+    context_imports
+FROM project_version
+WHERE project_id = @project_id
+ORDER BY version_number DESC
+LIMIT 1;

--- a/server/pkg/db/queries/project_versions.sql
+++ b/server/pkg/db/queries/project_versions.sql
@@ -4,7 +4,19 @@ VALUES (@project_id, @parent_version_id, @version_number, @branch_name, @fork_re
 RETURNING *;
 
 -- name: ListProjectVersions :many
-SELECT * FROM project_version WHERE project_id = @project_id ORDER BY version_number DESC;
+SELECT
+    id,
+    project_id,
+    parent_version_id,
+    version_number,
+    branch_name,
+    fork_reason,
+    version_status,
+    created_by,
+    created_at
+FROM project_version
+WHERE project_id = @project_id
+ORDER BY version_number DESC;
 
 -- name: GetProjectVersion :one
 SELECT * FROM project_version WHERE id = @id;


### PR DESCRIPTION
## Summary
- harden daemon execution decoding, workspace resolution, and runtime validation for the high-severity backend findings
- replace login hardcoded colors with design tokens and make `projects/[id]` load project, versions, and runs with abortable partial-error handling
- fix the project versions query/schema mismatch that caused a 500 after project creation
- make `make daemon` expand to `daemon start` and run the desktop daemon from source in dev mode instead of a stale `server/bin/myteam`
- realign the Playwright smoke suite with the current dashboard IA and isolate E2E identities so parallel runs stop fighting over verification codes
- document Doubao / Miaoji env vars in `.env.example` and ignore local pnpm/worktree/agent-skills directories

## Verification
- `cd server && go test ./internal/handler`
- `pnpm typecheck`
- `pnpm --filter @myteam/desktop exec vitest run electron/runtime-controller.test.ts`
- `pnpm --filter @myteam/desktop exec tsc --noEmit`
- `pnpm exec playwright test e2e/auth.spec.ts e2e/navigation.spec.ts e2e/comments.spec.ts e2e/issues.spec.ts e2e/settings.spec.ts --project=chromium --reporter=line`
- `make -n daemon`

## Closes
Closes #18, #19, #20, #21, #32, #33, #54, #55, #69, #70, #71, #72.