### PR TITLE
chore: review fixes round 5 — doubao PollMax, migration guard, interaction rate limit

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -151,6 +151,11 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 
 	r := chi.NewRouter()
 
+	// Per-sender rate limiter for the agent-to-agent messaging
+	// endpoint. Shared across all requests, mounted only on the send
+	// route below. See middleware/rate_limit.go for tuning.
+	interactionLimiter := middleware.NewInteractionRateLimiter()
+
 	// Global middleware
 	r.Use(chimw.RequestID)
 	r.Use(middleware.RequestLogger)
@@ -394,7 +399,10 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 			// broadcast / session-scoped message; schema field gives the
 			// receiver a routing hint for typed handlers.
 			r.Route("/api/interactions", func(r chi.Router) {
-				r.Post("/", h.SendInteraction)
+				// Rate limit only on send — ack and inbox reads
+				// don't fan out to other inboxes / the WS hub.
+				r.With(middleware.InteractionRateLimit(interactionLimiter)).
+					Post("/", h.SendInteraction)
 				r.Post("/{id}/ack", h.AckInteraction)
 			})
 

--- a/server/internal/middleware/rate_limit.go
+++ b/server/internal/middleware/rate_limit.go
@@ -1,0 +1,175 @@
+// Package middleware — per-sender rate limit for agent-to-agent messaging.
+//
+// See issue #78: POST /api/interactions was unbounded, so a misbehaving
+// agent (compromised PAT, runaway loop, etc.) could flood inboxes and
+// the WS broadcast fan-out. This middleware applies a per-sender token
+// bucket in front of the send endpoint only — inbox reads and ack
+// writes stay unthrottled since they don't amplify load the same way.
+//
+// Keyed by `{from_type}:{from_id}` so an agent and a user that happen
+// to share an id (they don't, but the compound key is cheap defense)
+// get independent budgets. In-memory only — fine for single-node; a
+// horizontal deploy needs a shared store (Redis, etc.).
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Bucket parameters. Sized for the issue #78 default of ~60 msgs/min
+// per sender, with a small burst allowance so a real agent that
+// batches a handful of fan-out calls doesn't hit 429 on the second
+// message. Tune here, not at call sites.
+const (
+	// interactionRefillPerSec is the steady-state allowance. 1.0 token
+	// per second == 60 messages per minute.
+	interactionRefillPerSec = 1.0
+	// interactionBurst is the bucket capacity — how many tokens a
+	// fresh sender starts with and the max it can accumulate.
+	interactionBurst = 20.0
+	// interactionIdleTTL is how long a bucket sticks around with no
+	// activity before the GC sweeps it. Long enough that a sender
+	// pausing briefly doesn't lose its partial refill; short enough
+	// that abandoned buckets don't leak memory.
+	interactionIdleTTL = 5 * time.Minute
+	// interactionGCInterval is how often the GC runs.
+	interactionGCInterval = 5 * time.Minute
+)
+
+// bucket is a simple token bucket. Access is serialized via the
+// limiter mutex — no per-bucket lock because the critical section is
+// a few arithmetic ops.
+type bucket struct {
+	tokens   float64
+	lastSeen time.Time
+}
+
+// RateLimiter holds the shared bucket map. A single instance is
+// created at router setup time and reused across all requests.
+type RateLimiter struct {
+	mu          sync.Mutex
+	buckets     map[string]*bucket
+	refillRate  float64 // tokens per second
+	burst       float64 // max tokens
+	idleTTL     time.Duration
+	now         func() time.Time // override in tests
+	stopGC      chan struct{}
+}
+
+// NewInteractionRateLimiter builds a limiter with the constants above
+// and starts the background GC goroutine. Callers should hold a
+// reference for the server lifetime; there's no Close() because the
+// process exits when the server stops.
+func NewInteractionRateLimiter() *RateLimiter {
+	rl := &RateLimiter{
+		buckets:    make(map[string]*bucket),
+		refillRate: interactionRefillPerSec,
+		burst:      interactionBurst,
+		idleTTL:    interactionIdleTTL,
+		now:        time.Now,
+		stopGC:     make(chan struct{}),
+	}
+	go rl.gcLoop(interactionGCInterval)
+	return rl
+}
+
+// allow returns true if the sender has a token to spend. If true, the
+// token is deducted and the bucket timestamp is refreshed.
+func (rl *RateLimiter) allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := rl.now()
+	b, ok := rl.buckets[key]
+	if !ok {
+		// New sender — full bucket minus the one token this request
+		// spends.
+		rl.buckets[key] = &bucket{
+			tokens:   rl.burst - 1,
+			lastSeen: now,
+		}
+		return true
+	}
+
+	// Refill based on elapsed time since lastSeen, capped at burst.
+	elapsed := now.Sub(b.lastSeen).Seconds()
+	if elapsed > 0 {
+		b.tokens += elapsed * rl.refillRate
+		if b.tokens > rl.burst {
+			b.tokens = rl.burst
+		}
+	}
+	b.lastSeen = now
+
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// gcLoop periodically evicts buckets idle longer than idleTTL.
+func (rl *RateLimiter) gcLoop(interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			rl.sweep()
+		case <-rl.stopGC:
+			return
+		}
+	}
+}
+
+func (rl *RateLimiter) sweep() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	cutoff := rl.now().Add(-rl.idleTTL)
+	for k, b := range rl.buckets {
+		if b.lastSeen.Before(cutoff) {
+			delete(rl.buckets, k)
+		}
+	}
+}
+
+// InteractionRateLimit returns an http middleware that enforces the
+// limiter against the sender resolved from request headers.
+//
+// Sender key priority:
+//   1. X-Agent-ID — set when the caller is acting as an agent. This
+//      matches handler.resolveActor's source of truth.
+//   2. X-User-ID — set by Auth middleware for every authenticated req.
+//   3. Remote address — fallback for the impossible case where both
+//      headers are missing; keeps the limiter from becoming a bypass
+//      if auth ordering ever regresses.
+//
+// On throttle: 429 + `Retry-After: 1` + JSON body matching the rest
+// of the API's error shape.
+func InteractionRateLimit(rl *RateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := senderKey(r)
+			if !rl.allow(key) {
+				w.Header().Set("Retry-After", "1")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"error":"rate limit exceeded"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func senderKey(r *http.Request) string {
+	if agentID := r.Header.Get("X-Agent-ID"); agentID != "" {
+		return "agent:" + agentID
+	}
+	if userID := r.Header.Get("X-User-ID"); userID != "" {
+		return "user:" + userID
+	}
+	return "addr:" + r.RemoteAddr
+}

--- a/server/internal/service/asr/doubao.go
+++ b/server/internal/service/asr/doubao.go
@@ -45,7 +45,7 @@ type MiaojiClient struct {
 	Endpoint   string        // override for tests; defaults to upstream
 	ResourceID string        // ASR resource id, default "volc.lark.minutes"
 	PollEvery  time.Duration // poll interval, default 2s
-	PollMax    time.Duration // total deadline, default 5min
+	PollMax    time.Duration // total deadline, default 30min
 }
 
 func NewMiaojiClient() *MiaojiClient {
@@ -54,7 +54,11 @@ func NewMiaojiClient() *MiaojiClient {
 		Endpoint:   "https://openspeech.bytedance.com",
 		ResourceID: "volc.lark.minutes",
 		PollEvery:  2 * time.Second,
-		PollMax:    5 * time.Minute,
+		// Doubao transcription can take ~1 min per 10 min audio; a 30 min
+		// cap covers multi-hour meetings with margin. The previous 5 min
+		// cap timed out long recordings (>30 min audio) before upstream
+		// finished transcription. See issue #64.
+		PollMax: 30 * time.Minute,
 	}
 }
 

--- a/server/migrations/063_meeting_in_session.down.sql
+++ b/server/migrations/063_meeting_in_session.down.sql
@@ -4,8 +4,23 @@ DROP INDEX IF EXISTS idx_thread_meeting_workspace;
 DROP INDEX IF EXISTS idx_thread_metadata_kind;
 
 -- Restore the original (narrower) item_type CHECK from migration 051.
--- WARNING: any rows with item_type = 'action_item' or 'briefing' must be
--- migrated/deleted before reverting, or this ALTER will fail.
+-- Guard: refuse rollback if rows exist with the widened item_type values.
+-- The operator must migrate or delete those rows explicitly before retrying.
+DO $$
+DECLARE
+    offending_count bigint;
+BEGIN
+    SELECT count(*) INTO offending_count
+    FROM thread_context_item
+    WHERE item_type IN ('action_item', 'briefing');
+
+    IF offending_count > 0 THEN
+        RAISE EXCEPTION
+            'refusing to narrow thread_context_item.item_type CHECK: % row(s) still use item_type IN (''action_item'',''briefing''); migrate or delete them before retrying rollback',
+            offending_count;
+    END IF;
+END $$;
+
 ALTER TABLE thread_context_item DROP CONSTRAINT IF EXISTS thread_context_item_item_type_check;
 ALTER TABLE thread_context_item
     ADD CONSTRAINT thread_context_item_item_type_check


### PR DESCRIPTION
Closes #17
Closes #64
Closes #78

## Summary

Three independent fixes, dispatched as 3 parallel subagents.

**Server:**
- **#64** — `asr/doubao.go` PollMax 5m → 30m.
- **#17** — `063_meeting_in_session.down.sql` adds `DO $$` guard with `RAISE EXCEPTION` before the ALTER.
- **#78** — New `middleware/rate_limit.go`: per-sender token bucket, 1/sec refill, burst 20. Mounted only on `POST /api/interactions`.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [ ] 30+ min meeting transcription
- [ ] 063.down with legacy rows → RAISE EXCEPTION
- [ ] 30 rapid POST /api/interactions → 429 after burst 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)