### PR TITLE
fix(web): green frontend CI — stable task-store selectors + inline thread test

### DIFF
--- a/apps/web/features/messaging/components/message-list.test.tsx
+++ b/apps/web/features/messaging/components/message-list.test.tsx
@@ -30,7 +30,7 @@ function buildMessage(overrides: Partial<{
 }
 
 describe("MessageList", () => {
-  it("renders messages and shows thread reply button that triggers onOpenThread", async () => {
+  it("renders thread chip for roots with replies and the hover icon triggers onOpenThread", async () => {
     const user = userEvent.setup();
     const onOpenThread = vi.fn();
 
@@ -58,12 +58,14 @@ describe("MessageList", () => {
     expect(screen.getByText("Hello world")).toBeInTheDocument();
     expect(screen.getByText("Another message")).toBeInTheDocument();
 
-    // The root message has reply_count=3, so thread button shows
-    const threadButton = screen.getByText("3 条回复");
-    expect(threadButton).toBeInTheDocument();
+    // Reply chip surfaces the count — it now toggles inline expansion
+    // instead of opening the side panel, so we assert the chip exists
+    // and the side-panel trigger is wired to the hover icon instead.
+    expect(screen.getByText(/3 条回复/)).toBeInTheDocument();
 
-    // Clicking the thread button calls onOpenThread with the message id
-    await user.click(threadButton);
+    const sidePanelTriggers = screen.getAllByTitle("在侧栏打开讨论串");
+    // Root message renders first, so its hover icon sits at index 0.
+    await user.click(sidePanelTriggers[0]);
     expect(onOpenThread).toHaveBeenCalledWith("root-message");
   });
 

--- a/apps/web/features/projects/components/task-list.tsx
+++ b/apps/web/features/projects/components/task-list.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect } from "react";
-import { useTaskStore } from "../task-store";
+import { selectTasksForPlan, useTaskStore } from "../task-store";
 import type { TaskStatus } from "@/shared/types";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
@@ -25,7 +25,7 @@ const STATUS_VARIANT: Record<
 };
 
 export function TaskList({ planID }: { planID: string }) {
-  const tasks = useTaskStore((s) => s.tasksByPlan[planID] ?? []);
+  const tasks = useTaskStore(selectTasksForPlan(planID));
   const loading = useTaskStore((s) => s.loading[planID] ?? false);
   const error = useTaskStore((s) => s.error);
   const loadTasks = useTaskStore((s) => s.loadTasks);

--- a/apps/web/features/projects/task-store.ts
+++ b/apps/web/features/projects/task-store.ts
@@ -14,7 +14,7 @@ import type {
 
 // State for Plan 5 task / slot / execution / artifact / review entities.
 // Kept separate from the existing project store to avoid clobbering its API.
-interface TaskState {
+export interface TaskState {
   tasksByPlan: Record<string, Task[]>;
   slotsByTask: Record<string, ParticipantSlot[]>;
   executionsByTask: Record<string, Execution[]>;
@@ -23,6 +23,42 @@ interface TaskState {
   loading: Record<string, boolean>;
   error: string | null;
 }
+
+// Shared empty arrays so selectors return a stable reference when the
+// keyed bucket is missing. Without this, `s.tasksByPlan[planID] ?? []`
+// produces a new array every render which trips zustand's equality
+// check into a re-render loop (the React warning "The result of
+// getSnapshot should be cached to avoid an infinite loop").
+const EMPTY_TASKS: Task[] = [];
+const EMPTY_SLOTS: ParticipantSlot[] = [];
+const EMPTY_EXECUTIONS: Execution[] = [];
+const EMPTY_ARTIFACTS: Artifact[] = [];
+const EMPTY_REVIEWS: Review[] = [];
+
+export const selectTasksForPlan =
+  (planID: string) =>
+  (s: TaskState): Task[] =>
+    s.tasksByPlan[planID] ?? EMPTY_TASKS;
+
+export const selectSlotsForTask =
+  (taskID: string) =>
+  (s: TaskState): ParticipantSlot[] =>
+    s.slotsByTask[taskID] ?? EMPTY_SLOTS;
+
+export const selectExecutionsForTask =
+  (taskID: string) =>
+  (s: TaskState): Execution[] =>
+    s.executionsByTask[taskID] ?? EMPTY_EXECUTIONS;
+
+export const selectArtifactsForTask =
+  (taskID: string) =>
+  (s: TaskState): Artifact[] =>
+    s.artifactsByTask[taskID] ?? EMPTY_ARTIFACTS;
+
+export const selectReviewsForArtifact =
+  (artifactID: string) =>
+  (s: TaskState): Review[] =>
+    s.reviewsByArtifact[artifactID] ?? EMPTY_REVIEWS;
 
 interface TaskActions {
   loadTasks: (planID: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- `task-store.ts` — export stable selector factories (`selectTasksForPlan`, `selectSlotsForTask`, `selectExecutionsForTask`, `selectArtifactsForTask`, `selectReviewsForArtifact`) that return shared `EMPTY_*` constants when the keyed bucket is empty. The old `s.tasksByPlan[id] ?? []` pattern allocated a new array every render, and zustand's default equality check re-rendered forever (React now reports "Maximum update depth exceeded").
- `task-list.tsx` — consume `selectTasksForPlan(planID)` instead of the inline selector to break the infinite loop surfaced by `task-list.test.tsx`.
- `message-list.test.tsx` — the reply-count chip now toggles inline expansion, so onOpenThread assertions are pointed at the hover icon (title `在侧栏打开讨论串`). Index 0 chosen because both rendered rows expose the same title.

## Test plan
- [x] `pnpm --filter @multica/web typecheck`
- [x] `pnpm --filter @multica/web test` — 23 files / 124 tests pass
- [ ] Backend race in `TestClaudePersistentIdleCleanup` is pre-existing; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)