### PR TITLE
fix(web): stop 400 on thread fetch — route ConversationRefItem to /api/threads/:id/messages

### DIFF
--- a/apps/web/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/projects/[id]/page.tsx
@@ -1267,6 +1267,19 @@ function ConversationRefItem({
           return [];
         }
       };
+      const tryFetchThread = async (threadId: string) => {
+        try {
+          const res = await api.getThreadMessages(threadId, 20);
+          return (res?.messages ?? []) as Array<{
+            id: string;
+            sender_id: string;
+            content: string;
+            created_at: string;
+          }>;
+        } catch {
+          return [];
+        }
+      };
       try {
         let all = await tryFetch({
           channel_id: conv.conversation_id,
@@ -1274,12 +1287,10 @@ function ConversationRefItem({
         });
         if (all.length === 0) {
           // Thread fallback — source_refs of type="thread" persist the
-          // thread's root message id as conversation_id. The backend
-          // accepts thread_id in listMessages directly.
-          all = await tryFetch({
-            thread_id: conv.conversation_id,
-            limit: 20,
-          });
+          // thread's own id as conversation_id. Backend ListMessages
+          // only accepts channel_id / recipient_id, so route to the
+          // dedicated /api/threads/:id/messages endpoint instead.
+          all = await tryFetchThread(conv.conversation_id);
         }
         if (all.length === 0) {
           // DM fallback — try both peer types so we don't require the

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -912,7 +912,11 @@ export class ApiClient implements ApiTransport {
     return this.fetch<any>('/api/messages', { method: 'POST', body: JSON.stringify(data) })
   }
 
-  async listMessages(params: { channel_id?: string; recipient_id?: string; peer_type?: "member" | "agent"; thread_id?: string; limit?: number; offset?: number }) {
+  // Backend /api/messages accepts channel_id or recipient_id only.
+  // For thread fetches use getThreadMessages(threadId) — hits the
+  // dedicated /api/threads/:id/messages route. Passing a thread_id
+  // here produces a 400.
+  async listMessages(params: { channel_id?: string; recipient_id?: string; peer_type?: "member" | "agent"; limit?: number; offset?: number }) {
     const qs = new URLSearchParams(Object.entries(params).filter(([,v]) => v != null).map(([k,v]) => [k, String(v)])).toString()
     return this.fetch<{ messages: any[] }>(`/api/messages?${qs}`)
   }


### PR DESCRIPTION
## Summary
ConversationRefItem in the project detail page falls back to \`api.listMessages({thread_id})\` when a source_ref's conversation_id turns out to be a thread id. Backend \`ListMessages\` only accepts \`channel_id\` or \`recipient_id\` (see \`server/internal/handler/message.go:204\`), so every fallback request logged a 400 in the browser console.

## Changes
- \`apps/web/app/(dashboard)/projects/[id]/page.tsx\` — add \`tryFetchThread(threadId)\` that calls \`api.getThreadMessages(threadId, 20)\` and wire it into the thread fallback branch.
- \`apps/web/shared/api/client.ts\` — drop \`thread_id\` from \`listMessages\` signature and leave a comment telling callers to use \`getThreadMessages\` instead, so the next developer doesn't rediscover the 400 path.

## Test plan
- [x] \`pnpm typecheck\`
- [ ] Manually open a project whose source_refs point at a thread → thread messages render, no 400 in devtools.
- [ ] Regression check: source_refs pointing at a channel or a DM still resolve through \`listMessages\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)