### PR TITLE
fix(web): clear myteam_* keys on 401, not the legacy multica_* pair

### DIFF
--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -119,6 +119,11 @@ export class ApiClient implements ApiTransport {
 
   handleUnauthorized() {
     if (typeof window !== "undefined") {
+      // Current storage keys — match the auth store + live ASR client.
+      localStorage.removeItem("myteam_token");
+      localStorage.removeItem("myteam_workspace_id");
+      // Legacy keys from the pre-rename build; purge so long-running
+      // browser sessions don't keep a stale multica_* pair alongside.
       localStorage.removeItem("multica_token");
       localStorage.removeItem("multica_workspace_id");
       this.token = null;


### PR DESCRIPTION
## Summary

- `handleUnauthorized` was still removing the pre-rename `multica_token` / `multica_workspace_id` keys, leaving the real `myteam_token` / `myteam_workspace_id` intact after a 401
- Clear the current keys first; keep removing the legacy names so long-running browser sessions don't keep a stale `multica_*` pair alongside

## Test plan

- [ ] Log in, then force a 401 (revoke token server-side or tamper with it in devtools) and confirm the client redirects to `/` and `localStorage` is empty of both key families
- [ ] Restart / hard-refresh — no auto-login from stale state

🤖 Generated with [Claude Code](https://claude.com/claude-code)